### PR TITLE
Fix nimcrypto/utils.fromHex conflict with the new strutils.fromHex

### DIFF
--- a/tests/test_vectors.nim
+++ b/tests/test_vectors.nim
@@ -6,7 +6,8 @@
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
-import strutils, os, unittest
+import strutils except fromHex
+import os, unittest
 import nimcrypto/[sysrand, hash, keccak, utils]
 import ../blscurve/milagro, ../blscurve/bls, ../blscurve/common
 


### PR DESCRIPTION
PR https://github.com/nim-lang/Nim/pull/11107 in `nim-lang/Nim` introduces new procs `fromHex` that conflicts with the `nimcrypto.fromHex` used in the `test_vectors.nim`.

To fix it, `fromHex` should not be imported from `strutils`.