### PR TITLE
IETF hash to g2

### DIFF
--- a/blscurve.nimble
+++ b/blscurve.nimble
@@ -5,7 +5,7 @@ description   = "BLS381-12 Curve implementation"
 license       = "Apache License 2.0"
 
 ### Dependencies
-requires "nim >= 0.19.6",
+requires "nim >= 1.0.4",
          "nimcrypto",
          "stew"
 
@@ -13,8 +13,12 @@ requires "nim >= 0.19.6",
 proc test(path: string, lang = "c") =
   if not dirExists "build":
     mkDir "build"
-  exec "nim " & lang & " --outdir:build -r " & path
+  exec "nim " & lang & " --outdir:build -r --hints:off --warnings:off " & path
 
 ### tasks
 task test, "Run all tests":
+  # Private prerequisites/primitives
+  test "blscurve/hkdf.nim"
+
+  # Public BLS API
   test "tests/all_tests.nim"

--- a/blscurve.nimble
+++ b/blscurve.nimble
@@ -17,8 +17,5 @@ proc test(path: string, lang = "c") =
 
 ### tasks
 task test, "Run all tests":
-  # Private prerequisites/primitives
-  test "blscurve/hkdf.nim"
-
   # Public BLS API
   test "tests/all_tests.nim"

--- a/blscurve.nimble
+++ b/blscurve.nimble
@@ -17,5 +17,9 @@ proc test(path: string, lang = "c") =
 
 ### tasks
 task test, "Run all tests":
+  # Debug - test intermediate computations
+  exec "nim c -r --hints:off --warnings:off --outdir:build blscurve/hkdf.nim"
+  exec "nim c -r --hints:off --warnings:off --outdir:build blscurve/hash_to_curve.nim"
+
   # Public BLS API
   test "tests/all_tests.nim"

--- a/blscurve.nimble
+++ b/blscurve.nimble
@@ -18,8 +18,8 @@ proc test(path: string, lang = "c") =
 ### tasks
 task test, "Run all tests":
   # Debug - test intermediate computations
-  exec "nim c -r --hints:off --warnings:off --outdir:build blscurve/hkdf.nim"
-  exec "nim c -r --hints:off --warnings:off --outdir:build blscurve/hash_to_curve.nim"
+  test "blscurve/hkdf.nim"
+  test "blscurve/hash_to_curve.nim"
 
   # Public BLS API
   test "tests/all_tests.nim"

--- a/blscurve/common.nim
+++ b/blscurve/common.nim
@@ -82,6 +82,14 @@ proc add*(x: FP2_BLS381, y: FP2_BLS381): FP2_BLS381 {.inline.} =
   ## Returns ``x + y``.
   FP2_BLS381_add(addr result, unsafeAddr x, unsafeAddr y)
 
+proc sub*(dst: var FP2_BLS381, x: FP2_BLS381, y: FP2_BLS381) {.inline.} =
+  ## Set ``dst`` to ``x - y``.
+  FP2_BLS381_sub(addr dst, unsafeAddr x, unsafeAddr y)
+
+proc sub*(x: FP2_BLS381, y: FP2_BLS381): FP2_BLS381 {.inline.} =
+  ## Returns ``x - y``.
+  FP2_BLS381_sub(addr result, unsafeAddr x, unsafeAddr y)
+
 proc shiftr*(a: var BIG_384, bits: int) {.inline.} =
   ## Shift big integer ``a`` to the right by ``bits`` bits.
   BIG_384_shr(a, cint(bits))
@@ -102,6 +110,16 @@ proc norm*(a: var FP2_BLS381) {.inline.} =
 proc sqr*(x: FP2_BLS381): FP2_BLS381 {.inline.} =
   ## Retruns ``x ^ 2``.
   FP2_BLS381_sqr(addr result, unsafeAddr x)
+
+proc sqrt*(a: var FP2_BLS381, b: FP2_BLS381): bool {.inline.} =
+  ## ``a ≡ sqrt(b) (mod q)``
+  ## Returns true if b is a quadratic residue
+  ## (i.e. congruent to a perfect square mod q)
+  return bool FP2_BLS381_sqrt(addr a, unsafeAddr b)
+
+proc pow*(a: FP2_BLS381, b: BIG_384): FP2_BLS381 {.inline.} =
+  ## Compute ``result = a^b (mod q)``
+  FP2_BLS381_pow(addr result, unsafeAddr a, b)
 
 proc nres*(a: BIG_384): FP_BLS381 {.inline.} =
   ## Convert big integer value to residue form mod Modulus.
@@ -240,6 +258,10 @@ proc mul*(a: var ECP2_BLS381, b: BIG_384) {.inline.} =
 proc mul*(a: var ECP_BLS381, b: BIG_384) {.inline.} =
   ## Multiply point ``a`` by big integer ``b``.
   ECP_BLS381_mul(addr a, b)
+
+proc div2*(a: FP2_BLS381): FP2_BLS381 {.inline.} =
+  ## Returns ``a div 2``
+  FP2_BLS381_div2(addr result, unsafeAddr a)
 
 proc get*(a: ECP2_BLS381, x, y: var FP2_BLS381): int {.inline.} =
   ## Get coordinates ``x`` and ``y`` from point ``a``.

--- a/blscurve/common.nim
+++ b/blscurve/common.nim
@@ -164,6 +164,11 @@ proc isinf*(a: ECP2_BLS381): bool {.inline.} =
   var tmp = a
   result = (ECP2_BLS381_isinf(addr tmp) != 0)
 
+proc inv*(a: FP2_BLS381): FP2_BLS381 {.inline.} =
+  ## Returns the reciprocal copy of ``a``
+  ## ``result = 1/a``
+  FP2_BLS381_inv(addr result, unsafeAddr a)
+
 proc rhs*(x: FP2_BLS381): FP2_BLS381 {.inline.} =
   ## Returns ``x ^ 3 + b``.
   ECP2_BLS381_rhs(addr result, unsafeAddr x)
@@ -212,6 +217,14 @@ proc double*(a: var ECP2_BLS381) {.inline.} =
 proc add*(a: var ECP_BLS381, b: ECP_BLS381) {.inline.} =
   ## Add point ``b`` to point ``a``.
   ECP_BLS381_add(addr a, unsafeAddr b)
+
+proc mul*(dst: var FP2_BLS381, x: FP2_BLS381, y: FP2_BLS381) {.inline.} =
+  ## Set ``dst`` to ``x * y``.
+  FP2_BLS381_mul(addr dst, unsafeAddr x, unsafeAddr y)
+
+proc mul*(x: FP2_BLS381, y: FP2_BLS381): FP2_BLS381 {.inline.} =
+  ## Returns ``x * y``.
+  FP2_BLS381_mul(addr result, unsafeAddr x, unsafeAddr y)
 
 proc mul*(a: var ECP2_BLS381, b: BIG_384) {.inline.} =
   ## Multiply point ``a`` by big integer ``b``.

--- a/blscurve/common.nim
+++ b/blscurve/common.nim
@@ -117,6 +117,10 @@ proc sqrt*(a: var FP2_BLS381, b: FP2_BLS381): bool {.inline.} =
   ## (i.e. congruent to a perfect square mod q)
   return bool FP2_BLS381_sqrt(addr a, unsafeAddr b)
 
+proc sqrt*(a: FP2_BLS381): FP2_BLS381 {.inline.} =
+  ## ``result ≡ sqrt(a) (mod q)``
+  discard FP2_BLS381_sqrt(addr result, unsafeAddr a)
+
 proc pow*(a: FP2_BLS381, b: BIG_384): FP2_BLS381 {.inline.} =
   ## Compute ``result = a^b (mod q)``
   FP2_BLS381_pow(addr result, unsafeAddr a, b)
@@ -201,6 +205,14 @@ proc cmov*(a: var FP2_BLS381, b: FP2_BLS381, c: bool) {.inline.} =
   ## if not c: a is unchanged
   ## This is a constant time operation
   FP2_BLS381_cmove(addr a, unsafeAddr b, cint(c))
+
+proc cmov*(a: FP2_BLS381, b: FP2_BLS381, c: bool): FP2_BLS381 {.inline.} =
+  ## Conditional copy of FP2 element (without branching)
+  ## if c: result = b
+  ## if not c: result = a
+  ## This is a constant time operation
+  result = a
+  FP2_BLS381_cmove(addr result, unsafeAddr b, cint(c))
 
 proc parity*(a: FP2_BLS381): int {.inline.} =
   ## Returns parity for ``a``.

--- a/blscurve/common.nim
+++ b/blscurve/common.nim
@@ -576,6 +576,18 @@ proc fromBytes*(res: var BIG_384, a: openarray[byte]): bool =
     res[0] = res[0] + cast[Chunk](a[i])
   result = true
 
+proc fromBytes*(res: var DBIG_384, a: openarray[byte]): bool =
+  ## Unserialize double big integer from ``a`` to ``res``.
+  ## Length of ``a`` must be at least ``2*MODBYTES_384_29``.
+
+  # TODO: there is no length check in Milagro BIG_384_29_dfromBytesLen
+  #       is that normal?
+
+  for rawByte in a:
+    BIG_384_dshl(res, 8)
+    res[0] = res[0] + cast[Chunk](rawByte)
+  result = true
+
 proc fromHex*(res: var BIG_384, a: string): bool {.inline.} =
   ## Unserialize big integer from hexadecimal string ``a`` to ``res``.
   ##

--- a/blscurve/common.nim
+++ b/blscurve/common.nim
@@ -177,6 +177,13 @@ proc iszilch*(a: FP2_BLS381): bool {.inline.} =
   ## Returns ``true`` if ``a`` is zero.
   result = (FP2_BLS381_iszilch(unsafeAddr a) == 1)
 
+proc cmov*(a: var FP2_BLS381, b: FP2_BLS381, c: bool) {.inline.} =
+  ## Conditional copy of FP2 element (without branching)
+  ## if c: a = b
+  ## if not c: a is unchanged
+  ## This is a constant time operation
+  FP2_BLS381_cmove(addr a, unsafeAddr b, cint(c))
+
 proc parity*(a: FP2_BLS381): int {.inline.} =
   ## Returns parity for ``a``.
   var t: BIG_384

--- a/blscurve/hash_to_curve.md
+++ b/blscurve/hash_to_curve.md
@@ -322,3 +322,42 @@ by the equivalent h_eff; these two methods give the same result.
 Note that in this case scalar multiplication by the cofactor h does
 not generally give the same result as the fast method, and SHOULD NOT
 be used.
+
+BLS 12-381 suite
+----------------------------------------------------------------------
+Section 8.9.2
+
+Group G2 of BLS12-381 is defined over a field F = GF(p^m) defined as:
+
+- p: 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+- m: 2
+- (1, I) is the basis for F, where I^2 + 1 == 0 in F
+
+The suites BLS12381G2-SHA256-SSWU-RO- and BLS12381G2-SHA256-SSWU-NU-
+share the following parameters, in addition to the common parameters below.
+
+- f: Simplified SWU for AB == 0, {{simple-swu-AB0}}
+- Z: -(2 + I)
+- E': y'^2 = x'^3 + A' * x' + B', where
+  - A' = 240 * I
+  - B' = 1012 * (1 + I)
+- iso\_map: the isogeny map from E' to E given in {{appx-iso-bls12381-g2}}
+
+The suites BLS12381G2-SHA256-SVDW-RO- and BLS12381G2-SHA256-SVDW-NU-
+share the following parameters, in addition to the common parameters below.
+
+- f: Shallue-van de Woestijne method, {{svdw}}
+- Z: I
+
+The common parameters for the above suites are:
+
+- E: y^2 = x^3 + 4 * (1 + I)
+- p, m, F: defined above
+- sgn0: sgn0\_be (sgn0-be)
+- H: SHA-256
+- L: 64
+- h\_eff: 0xbc69f08f2ee75b3584c6a0ea91b352888e2a8e9145ad7689986ff031508ffe1329c2f178731db956d82bf015d1212b02ec0ec69d7477c1ae954cbc06689f6a359894c0adebbf6b4e8020005aaa95551
+
+Note that this h\_eff value is chosen for compatibility
+with the fast cofactor clearing method described by
+Budroni and Pintore (BP18, Section 4.1).

--- a/blscurve/hash_to_curve.md
+++ b/blscurve/hash_to_curve.md
@@ -5,17 +5,12 @@ for the BLS12-381 pairing-friendly elliptic curve.
 
 Hash to Elliptic curve implementation for BLS12-381.
 - IETF Standard Draft: https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04
-  - Algorithm description in section 8.7
-  - This includes a specific appendix for BLS12-381 (Appendix C)
+  - Formatted HTML version: https://cfrg.github.io/draft-irtf-cfrg-hash-to-curve/draft-irtf-cfrg-hash-to-curve.html
 - IETF Implementation: https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve
   - The following can be used as a test vector generator:
     https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve/blob/6cf7fa97/poc/suite_bls12381g2.sage
 - Ethereum Foundation implementation: https://github.com/ethereum/py_ecc
   - Specific PR: https://github.com/ethereum/py_ecc/pull/83/files
-
-> ⚠️ Important: the standard seem to assume that strings are 0x00 terminated
-           and that that null bytes is part of the hashed message.
-
 
 hash_to_curve
 ----------------------------------------------------------------------
@@ -99,6 +94,19 @@ Steps:
 4.   t = HKDF-Expand(m', info, L)
 5.   e_i = OS2IP(t) mod p
 6. return u = (e_1, ..., e_m)
+
+> ⚠️ Important:
+>   in the invocation of HKDF-Extract, the message is
+>   the message is appended with a null-byte
+>
+>   Section 5.1
+>   > Finally, hash_to_base appends one zero byte to msg in the invocation
+>   > of HKDF-Extract. This ensures that the use of HKDF in hash_to_base
+>   > This ensures that the use of HKDF in hash_to_base
+>   > is indifferentiable from a random oracle (see \[LBB19\], Lemma 8 and
+>   > \[DRST12\], Theorems 4.3 and 4.4).  (In particular, this approach works
+>   > because it ensures that the final byte of each HMAC invocation in
+>   > HKDF-Extract and HKDF-Expand is distinct.)
 
 > 🛈 Note:
 >

--- a/blscurve/hash_to_curve.md
+++ b/blscurve/hash_to_curve.md
@@ -4,7 +4,7 @@ This document extracts part of the draft standard for hash-to-G2 implementation
 for the BLS12-381 pairing-friendly elliptic curve.
 
 Hash to Elliptic curve implementation for BLS12-381.
-- IETF Standard Draft: https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04
+- IETF Standard Draft: https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-05
   - Formatted HTML version: https://cfrg.github.io/draft-irtf-cfrg-hash-to-curve/draft-irtf-cfrg-hash-to-curve.html
 - IETF Implementation: https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve
   - The following can be used as a test vector generator:

--- a/blscurve/hash_to_curve.md
+++ b/blscurve/hash_to_curve.md
@@ -183,6 +183,50 @@ Operations:
 9.  If sgn0(u) != sgn0(y), set y = -y
 10. return (x, y)
 
+Implementation
+
+> 🛈 This is a constant-time implementation
+
+The following procedure implements the simplified SWU mapping in a straight-line fashion.
+Appendix D gives an optimized straight-line procedure for P-256.
+For more information on optimizing this mapping, see
+Wahby and Boneh Section 4 or the example code found at [hash2curve-repo](https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve).
+
+~~~
+map_to_curve_simple_swu(u)
+Input: u, an element of F.
+Output: (x, y), a point on E.
+
+Constants:
+1.  c1 = -B / A
+2.  c2 = -1 / Z
+
+Steps:
+1.  tv1 = Z * u^2
+2.  tv2 = tv1^2
+3.   x1 = tv1 + tv2
+4.   x1 = inv0(x1)
+5.   e1 = x1 == 0
+6.   x1 = x1 + 1
+7.   x1 = CMOV(x1, c2, e1)    # If (tv1 + tv2) == 0, set x1 = -1 / Z
+8.   x1 = x1 * c1      # x1 = (-B / A) * (1 + (1 / (Z^2 * u^4 + Z * u^2)))
+9.  gx1 = x1^2
+10. gx1 = gx1 + A
+11. gx1 = gx1 * x1
+12. gx1 = gx1 + B             # gx1 = g(x1) = x1^3 + A * x1 + B
+13.  x2 = tv1 * x1            # x2 = Z * u^2 * x1
+14. tv2 = tv1 * tv2
+15. gx2 = gx1 * tv2           # gx2 = (Z * u^2)^3 * gx1
+16.  e2 = is_square(gx1)
+17.   x = CMOV(x2, x1, e2)    # If is_square(gx1), x = x1, else x = x2
+18.  y2 = CMOV(gx2, gx1, e2)  # If is_square(gx1), y2 = gx1, else y2 = gx2
+19.   y = sqrt(y2)
+20.  e3 = sgn0(u) == sgn0(y)  # Fix sign of y
+21.   y = CMOV(-y, y, e3)
+22. return (x, y)
+~~~
+
+
 3-isogeny map for BLS12-381 G2
 ----------------------------------------------------------------------
 Appendix C.2

--- a/blscurve/hash_to_curve.md
+++ b/blscurve/hash_to_curve.md
@@ -1,0 +1,223 @@
+# BLS12-381 Hash-to-G2 Curve
+
+This document extracts part of the draft standard for hash-to-G2 implementation
+for the BLS12-381 pairing-friendly elliptic curve.
+
+Hash to Elliptic curve implementation for BLS12-381.
+- IETF Standard Draft: https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04
+  - Algorithm description in section 8.7
+  - This includes a specific appendix for BLS12-381 (Appendix C)
+- IETF Implementation: https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve
+  - The following can be used as a test vector generator:
+    https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve/blob/6cf7fa97/poc/suite_bls12381g2.sage
+- Ethereum Foundation implementation: https://github.com/ethereum/py_ecc
+  - Specific PR: https://github.com/ethereum/py_ecc/pull/83/files
+
+> ⚠️ Important: the standard seem to assume that strings are 0x00 terminated
+           and that that null bytes is part of the hashed message.
+
+
+hash_to_curve
+----------------------------------------------------------------------
+Section 3 - https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04#section-3
+
+This section presents a general framework for encoding bit strings to
+points on an elliptic curve.  To construct these encodings, we rely
+on three basic functions:
+
+o  The function hash_to_base, {0, 1}^* x {0, 1, 2} -> F, hashes
+   arbitrary-length bit strings to elements of a finite field; its
+   implementation is defined in Section 5.
+
+o  The function map_to_curve, F -> E, calculates a point on the
+   elliptic curve E from an element of the finite field F over which
+   E is defined.  Section 6 describes mappings for a range of curve
+   families.
+
+o  The function clear_cofactor, E -> G, sends any point on the curve
+   E to the subgroup G of E.  Section 7 describes methods to perform
+   this operation.
+
+[...] (Overview of encode_to_curve)
+
+Random oracle encoding (hash_to_curve).
+  This function encodes bitstrings to points in G.
+  The distribution of the output is
+  indistinguishable from uniformly random in G provided that
+  map_to_curve is "well distributed" (\[FFSTV13\], Def. 1).  All of
+  the map_to_curve functions defined in Section 6 meet this
+  requirement.
+
+  hash_to_curve(alpha)
+
+  Input: alpha, an arbitrary-length bit string.
+  Output: P, a point in G.
+
+  Steps:
+  1. u0 = hash_to_base(alpha, 0)
+  2. u1 = hash_to_base(alpha, 1)
+  3. Q0 = map_to_curve(u0)
+  4. Q1 = map_to_curve(u1)
+  5. R = Q0 + Q1      // point addition
+  6. P = clear_cofactor(R)
+  7. return P
+
+  Instances of these functions are given in Section 8, which defines a
+  list of suites that specify a full set of parameters matching
+  elliptic curves and algorithms.
+
+hash_to_base
+----------------------------------------------------------------------
+Section 5.3 - https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04#section-5.3
+
+The following procedure implements hash_to_base.
+
+hash_to_base(msg, ctr)
+
+Parameters:
+- DST, a domain separation tag (see discussion above).
+- H, a cryptographic hash function.
+- F, a finite field of characteristic p and order q = p^m.
+- L = ceil((ceil(log2(p)) + k) / 8), where k is the security
+  parameter of the cryptosystem (e.g., k = 128).
+- HKDF-Extract and HKDF-Expand are as defined in RFC5869,
+  instantiated with the hash function H.
+
+Inputs:
+- msg is the message to hash.
+- ctr is 0, 1, or 2.
+  This is used to efficiently create independent
+  instances of hash_to_base (see discussion above).
+
+Output:
+- u, an element in F.
+
+Steps:
+1. m' = HKDF-Extract(DST, msg)
+2. for i in (1, ..., m):
+3.   info = "H2C" || I2OSP(ctr, 1) || I2OSP(i, 1)
+4.   t = HKDF-Expand(m', info, L)
+5.   e_i = OS2IP(t) mod p
+6. return u = (e_1, ..., e_m)
+
+> 🛈 Note:
+>
+>   I2OSP and OS2IP: These primitives are used to convert an octet string to
+>   and from a non-negative integer as described in RFC8017.
+>   https://tools.ietf.org/html/rfc8017#section-4
+>
+>   In summary those are bigEndian <-> integer conversion routine with the following signatures
+>   - proc I2OSP(n: BigInt, resultLen: Natural): string
+>   - proc OS2IP(s: string): BigInt
+
+
+map_to_curve
+----------------------------------------------------------------------
+6.9.2.  Simplified SWU for Pairing-Friendly Curves - https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04#section-6.9.2
+
+_Simplified Shallue-van de Woestijne-Ulas Method for pairing-friendly curves_
+
+> Wahby, R. and D. Boneh,
+>
+> "Fast and simple constant-time hashing to the BLS12-381 elliptic curve",
+>
+> Technical report ePrint 2019/403, 2019,
+> <https://eprint.iacr.org/2019/403>
+
+Explanation
+1. find a curve E' that is isogenous to the target curve E
+   E' parametrized by y^2 = g'(x) = x^3 + A' * x + B'
+2. Then isogeny map E' => E
+
+Step 1 follows the simplified SWU method 6.5.2
+(Simplified Shallue-van de Woestijne-Ulas Method)
+
+Step 2 BLS12-381 isogeny map is detailed in Appendix C.2https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04#appendix-C.2
+
+simplified_swu
+----------------------------------------------------------------------
+6.5.2. Simplified SWU -  https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04#section-6.5.2
+
+_Simplified Shallue-van de Woestijne-Ulas Method_
+
+> Brier, E., Coron, J., Icart, T., Madore, D., Randriam, H., and M. Tibouchi
+>
+> "Efficient Indifferentiable Hashing into Ordinary Elliptic Curves",
+>
+> In Advances in Cryptology - CRYPTO 2010, pages 237-254,
+>
+> DOI 10.1007/978-3-642-14623-7_13, 2010,
+> <https://doi.org/10.1007/978-3-642-14623-7_13>.
+
+Preconditions: A Weierstrass curve y^2 = x^3 + A * x + B where A != 0 and B != 0.
+
+Constants:
+
+- A and B, the parameters of the Weierstrass curve.
+
+- Z, an element of F meeting the below criteria.
+  1. Z is non-square in F,
+  2. Z != -1 in F,
+  3. the polynomial g(x) - Z is irreducible over F, and
+  4. g(B / (Z * A)) is square in F.
+
+Sign of y: Inputs u and -u give the same x-coordinate.
+Thus, we set sgn0(y) == sgn0(u).
+
+Exceptions: The exceptional cases are values of u such that
+Z^2 * u^4 + Z * u^2 == 0. This includes u == 0, and may include
+other values depending on Z. Implementations must detect
+this case and set x1 = B / (Z * A), which guarantees that g(x1)
+is square by the condition on Z given above.
+
+Operations:
+
+1. tv1 = inv0(Z^2 * u^4 + Z * u^2)
+2.  x1 = (-B / A) * (1 + tv1)
+3.  If tv1 == 0, set x1 = B / (Z * A)
+4. gx1 = x1^3 + A * x1 + B
+5.  x2 = Z * u^2 * x1
+6. gx2 = x2^3 + A * x2 + B
+7.  If is_square(gx1), set x = x1 and y = sqrt(gx1)
+8.  Else set x = x2 and y = sqrt(gx2)
+9.  If sgn0(u) != sgn0(y), set y = -y
+10. return (x, y)
+
+3-isogeny map for BLS12-381 G2
+----------------------------------------------------------------------
+Appendix C.2
+
+The 3-isogeny map from (x', y') on E' to (x, y) on E is given by the following rational functions:
+
+- x = x\_num / x\_den, where
+  - x\_num = k\_(1,3) * x'^3 + k\_(1,2) * x'^2 + k\_(1,1) * x' + k\_(1,0)
+  - x\_den = x'^2 + k\_(2,1) * x' + k\_(2,0)
+
+- y = y' * y\_num / y\_den, where
+  - y\_num = k\_(3,3) * x'^3 + k\_(3,2) * x'^2 + k\_(3,1) * x' + k\_(3,0)
+  - y\_den = x'^3 + k\_(4,2) * x'^2 + k\_(4,1) * x' + k\_(4,0)
+
+The constants used to compute x\_num are as follows:
+
+- k\_(1,0) = 0x5c759507e8e333ebb5b7a9a47d7ed8532c52d39fd3a042a88b58423c50ae15d5c2638e343d9c71c6238aaaaaaaa97d6 + 0x5c759507e8e333ebb5b7a9a47d7ed8532c52d39fd3a042a88b58423c50ae15d5c2638e343d9c71c6238aaaaaaaa97d6 * I
+- k\_(1,1) = 0x11560bf17baa99bc32126fced787c88f984f87adf7ae0c7f9a208c6b4f20a4181472aaa9cb8d555526a9ffffffffc71a * I
+- k\_(1,2) = 0x11560bf17baa99bc32126fced787c88f984f87adf7ae0c7f9a208c6b4f20a4181472aaa9cb8d555526a9ffffffffc71e + 0x8ab05f8bdd54cde190937e76bc3e447cc27c3d6fbd7063fcd104635a790520c0a395554e5c6aaaa9354ffffffffe38d * I
+- k\_(1,3) = 0x171d6541fa38ccfaed6dea691f5fb614cb14b4e7f4e810aa22d6108f142b85757098e38d0f671c7188e2aaaaaaaa5ed1
+
+The constants used to compute x\_den are as follows:
+
+- k\_(2,0) = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa63 * I
+- k\_(2,1) = 0xc + 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa9f * I
+
+The constants used to compute y\_num are as follows:
+
+- k\_(3,0) = 0x1530477c7ab4113b59a4c18b076d11930f7da5d4a07f649bf54439d87d27e500fc8c25ebf8c92f6812cfc71c71c6d706 + 0x1530477c7ab4113b59a4c18b076d11930f7da5d4a07f649bf54439d87d27e500fc8c25ebf8c92f6812cfc71c71c6d706 * I
+- k\_(3,1) = 0x5c759507e8e333ebb5b7a9a47d7ed8532c52d39fd3a042a88b58423c50ae15d5c2638e343d9c71c6238aaaaaaaa97be * I
+- k\_(3,2) = 0x11560bf17baa99bc32126fced787c88f984f87adf7ae0c7f9a208c6b4f20a4181472aaa9cb8d555526a9ffffffffc71c + 0x8ab05f8bdd54cde190937e76bc3e447cc27c3d6fbd7063fcd104635a790520c0a395554e5c6aaaa9354ffffffffe38f * I
+- k\_(3,3) = 0x124c9ad43b6cf79bfbf7043de3811ad0761b0f37a1e26286b0e977c69aa274524e79097a56dc4bd9e1b371c71c718b10
+
+The constants used to compute y\_den are as follows:
+
+- k\_(4,0) = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa8fb + 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa8fb * I
+- k\_(4,1) = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa9d3 * I
+- k\_(4,2) = 0x12 + 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa99 * I

--- a/blscurve/hash_to_curve.md
+++ b/blscurve/hash_to_curve.md
@@ -237,7 +237,7 @@ Steps:
 
 3-isogeny map for BLS12-381 G2
 ----------------------------------------------------------------------
-Appendix C.2
+Appendix C.3
 
 The 3-isogeny map from (x', y') on E' to (x, y) on E is given by the following rational functions:
 

--- a/blscurve/hash_to_curve.md
+++ b/blscurve/hash_to_curve.md
@@ -273,3 +273,52 @@ The constants used to compute y\_den are as follows:
 - k\_(4,0) = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa8fb + 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa8fb * I
 - k\_(4,1) = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa9d3 * I
 - k\_(4,2) = 0x12 + 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa99 * I
+
+Clear cofactor
+----------------------------------------------------------------------
+Section 7
+
+The mappings of Section 6 always output a point on the elliptic
+curve, i.e., a point in a group of order h * r (Section 2.1).
+Obtaining a point in G may require a final operation commonly called
+"clearing the cofactor," which takes as input any point on the curve.
+
+The cofactor can always be cleared via scalar multiplication by h.
+For elliptic curves where h = 1, i.e., the curves with a prime number
+of points, no operation is required.  This applies, for example, to
+the NIST curves P-256, P-384, and P-521 \[FIPS186-4\].
+
+In some cases, it is possible to clear the cofactor via a faster
+method than scalar multiplication by h.  These methods are equivalent
+to (but usually faster than) multiplication by some scalar h_eff
+whose value is determined by the method and the curve.  Examples of
+fast cofactor clearing methods include the following:
+
+o  For certain pairing-friendly curves having subgroup G2 over an
+  extension field, Scott et al.  \[SBCDK09\] describe a method for
+  fast cofactor clearing that exploits an efficiently-computable
+  endomorphism.  Fuentes-Castaneda et al.  \[FKR11\] propose an
+  alternative method that is sometimes more efficient.  Budroni and
+  Pintore \[BP18\] give concrete instantiations of these methods for
+  Barreto-Lynn-Scott pairing-friendly curves \[BLS03\].
+
+o  Wahby and Boneh (\[WB19\], Section 5) describe a trick due to Scott
+  for fast cofactor clearing on any elliptic curve for which the
+  prime factorization of h and the structure of the elliptic curve
+  group meet certain conditions.
+
+The clear_cofactor function is parameterized by a scalar h_eff.
+Specifically,
+
+clear_cofactor(P) := h_eff * P
+
+where * represents scalar multiplication.  When a curve does not
+support a fast cofactor clearing method, h_eff = h and the cofactor
+MUST be cleared via scalar multiplication.
+
+When a curve admits a fast cofactor clearing method, clear_cofactor
+MAY be evaluated either via that method or via scalar multiplication
+by the equivalent h_eff; these two methods give the same result.
+Note that in this case scalar multiplication by the cofactor h does
+not generally give the same result as the fast method, and SHOULD NOT
+be used.

--- a/blscurve/hash_to_curve.nim
+++ b/blscurve/hash_to_curve.nim
@@ -276,48 +276,51 @@ func isogeny_map_G2(xp, yp: FP2_BLS381): ECP2_BLS381 =
       "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa99"
     )
 
-  let xp2 = sqr(xp)
-  let xp3 = mul(xp, xp2)
+  var xp2 = sqr(xp)
+  norm(xp2)
+  var xp3 = mul(xp, xp2)
+  norm(xp3)
+
   {.noSideEffect.}: # TODO overload `+` and `*` for readability
     # xNum = k(1,3) * x'³ + k(1,2) * x'² + k(1,1) * x' + k(1,0)
-    let xNum = (
-                 k13.mul(xp3)
-               ).add(
-                 k12.mul(xp2)
-               ).add(
-                 k11.mul(xp)
-               ).add(
-                 k10
-               )
+    let xNum = block:
+      var xNum = k13.mul(xp3)
+      norm(xNum)
+      xNum.add xNum, k12.mul(xp2)
+      norm(xNum)
+      xNum.add xNum, k11.mul(xp)
+      norm(xNum)
+      xNum.add xNum, k10
+      xNum
+
     # xDen = x'² + k(2,1) * x' + k(2,0)
-    let xDen = (
-                 xp2
-               ).add(
-                 k21.mul(xp)
-               ).add(
-                 k20
-               )
+    let xDen = block:
+      var xDen = xp2
+      xDen.add xDen, k21.mul(xp)
+      norm(xDen)
+      xDen.add xDen, k20
+      xDen
 
     # yNum = k(3,3) * x'³ + k(3,2) * x'² + k(3,1) * x' + k(3,0)
-    let yNum = (
-                 k33.mul(xp3)
-               ).add(
-                 k32.mul(xp2)
-               ).add(
-                 k31.mul(xp)
-               ).add(
-                 k30
-               )
+    let yNum = block:
+      var yNum = k33.mul(xp3)
+      norm(yNum)
+      yNum.add yNum, k32.mul(xp2)
+      norm(yNum)
+      yNum.add yNum, k31.mul(xp)
+      norm(yNum)
+      yNum.add yNum, k30
+      yNum
+
     # yDen = x'³ + k(4,2) * x'² + k(4,1) * x' + k(4,0)
-    let yDen = (
-                 xp3
-               ).add(
-                 k42.mul(xp2)
-               ).add(
-                 k41.mul(xp)
-               ).add(
-                 k40
-               )
+    let yDen = block:
+      var yDen = xp3
+      yDen.add yDen, k42.mul(xp2)
+      norm(yDen)
+      yDen.add yDen, k41.mul(xp)
+      norm(yDen)
+      yDen.add yDen, k40
+      yDen
 
   let x = xNum.mul inv(xDen)
   let y = yp.mul yNum.mul inv(yDen)

--- a/blscurve/hash_to_curve.nim
+++ b/blscurve/hash_to_curve.nim
@@ -176,7 +176,7 @@ func mapToIsoCurveSimpleSWU_G2(u: FP2_BLS381): tuple[x, y: FP2_BLS381] =
       A {.global.} = toFP2(   0,  240)   # A' = 240 * I
       B {.global.} = toFP2(1012, 1012)   # B' = 1012 * (1+I)
       Z {.global.} = neg toFP2(2, 1)     # Z  = -(2+I)
-      c1 {.global.} = neg mul(B, inv(A)) # -B/A -- TODO: can we compute that as -(B * 1/A)
+      c1 {.global.} = neg mul(B, inv(A)) # -B/A
       c2 {.global.} = neg inv(Z)         # -1/Z
 
     var one {.global.} = block:
@@ -308,7 +308,7 @@ func isogeny_map_G2(xp, yp: FP2_BLS381): ECP2_BLS381 =
                ).add(
                  k30
                )
-    # yDen = x'³ + k(4,2) * x'2 + k(4,1) * x' + k(4,0)
+    # yDen = x'³ + k(4,2) * x'² + k(4,1) * x' + k(4,0)
     let yDen = (
                  xp3
                ).add(

--- a/blscurve/hash_to_curve.nim
+++ b/blscurve/hash_to_curve.nim
@@ -346,7 +346,7 @@ func clearCofactor(P: ECP2_BLS381): ECP2_BLS381 =
   ##
   ## Described in https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-05#section-7
   #
-  # Implementations, multiple implementations are possible in decreasing order of speed:
+  # Implementations, multiple implementations are possible in increasing order of speed:
   #
   # - The default, canonical, implementation is h_eff * P
   # - Scott et al, "Fast Hashing to G2 on Pairing-Friendly Curves", https://doi.org/10.1007/978-3-642-03298-1_8

--- a/blscurve/hash_to_curve.nim
+++ b/blscurve/hash_to_curve.nim
@@ -263,15 +263,15 @@ func isogeny_map_G2(xp, yp: FP2_BLS381): ECP2_BLS381 =
       "0x00"
     )
     # Constants to compute y_denominator
-    let k40 = hexToFP2(
+    let k40 {.global.} = hexToFP2(
       "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa8fb",
       "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa8fb"
     )
-    let k41 = hexToFP2(
+    let k41 {.global.} = hexToFP2(
       "0x00",
       "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa9d3"
     )
-    let k42 = hexToFP2(
+    let k42 {.global.} = hexToFP2(
       "0x12",
       "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa99"
     )
@@ -426,6 +426,9 @@ func hashToG2*(message, domainSepTag: string): ECP2_BLS381 =
 
 # Unofficial test vectors for hashToG2 primitives
 # ----------------------------------------------------------------------
+#
+# Those unofficial vectors are intended for debugging the building blocks of
+# of the full hashToG2 function
 
 when isMainModule:
   import stew/byteutils, nimcrypto/[sha2, hmac]
@@ -442,6 +445,11 @@ when isMainModule:
     var x, y: FP2_BLS381
     discard ECP2_BLS381_get(x.addr, y.addr, point.unsafeAddr)
     echo "(", $x, ", ", $y, ")"
+
+  proc toECP2(x, y: FP2_BLS381): ECP2_BLS381 =
+    ## Create a point (x, y) on the G2 curve
+    let onCurve = bool ECP2_BLS381_set(addr result, unsafeAddr x, unsafeAddr y)
+    doAssert onCurve, "The coordinates (x, y) are not on the G2 curve"
 
   # Test vectors for hashToBaseFP2
   # ----------------------------------------------------------------------
@@ -463,24 +471,34 @@ when isMainModule:
         ctr,
         pdst, dst.len.uint
       )
-      echo pointFP2
+      doAssert fp2 == pointFP2
+      echo "Success hashToBaseFP2 ", astToStr(id)
 
     `test _ id`()
 
   block: # hashToBaseFP2
-    testHashToBaseFP2 1:
+    testHashToBaseFP2 msg_ctr0:
       let
         msg = "msg"
         ctr = 0'i8
         dst = "BLS_SIG_BLS12381G2-SHA256-SSWU-RO_POP_"
 
-      # Expected output after hkdfExpand
-      let t = [
-        "0x3852c6c62ecd4e04360c24e8ddeac03661b07575a60d6fb7b0a90ce0bb7c7667624fbeea77777e52099dd43356e03192b3d4d27264fd09d0afadda24f48b6f2c",
-        "0x099695b4dc8d5dbebc73a9856cc859a3e5317e9a9e0459ee8fc03646bdcfe30125aa434dda228311f25d8c227d5eee289dd6a50897c08397565bc826c5c4113d"
-      ]
+      let fp2 = hexToFP2(
+        x = "0x18df4dc51885b18ca0082a4966b0def46287930b8f1c0b673b11ac48d19c8899bc150d83fd3a7a1430b0de541742c1d4",
+        y = "0x14eef8ca34b82d065d187a3904cb313dbb44558917cc5091574d9999b5ecfdd5af2fa3aea6e02fb253bf4ae670e72d55"
+      )
 
-      # TODO: doAssert the FP2
+  block:
+    testHashToBaseFP2 msg_ctr1:
+      let
+        msg = "msg"
+        ctr = 1'i8
+        dst = "BLS_SIG_BLS12381G2-SHA256-SSWU-RO_POP_"
+
+      let fp2 = hexToFP2(
+        x = "0x14c81e3d32a930af141ff28f337e375bd7f2b35d006b2f6ba9a4c9eed7937e2b20d8b251fef776b0d497859510c9fad7",
+        y = "0x05764cf5fe69554b971c5fe77eb3f3f9b89534547335b84ff02cd3d613bcd5e3037005b9226011a61a70b5bd0f0db570"
+      )
 
   # Test vectors for mapToCurveG2
   # ----------------------------------------------------------------------
@@ -502,12 +520,14 @@ when isMainModule:
       P.add(q1)
 
       P.clearCofactor()
-      displayECP2Coord("P", P)
+      # displayECP2Coord("P", P)
 
+      doAssert P == ecp
+      echo "Success mapToCurveG2 ", astToStr(id)
 
     `test _ id`()
 
-  block: # hashToBaseFP2
+  block:
     testMapToCurveG2 MilagroRust_1:
       let
         u0x = "0x004ad233c619209060e40059b81e4c1f92796b05aa1bc6358d65e53dc0d657dfbc713d4030b0b6d9234a6634fd1944e7"
@@ -516,18 +536,23 @@ when isMainModule:
         u1y = "0x07016d0e5e13cd65780042c6f7b4c74ae1c58da438c99582696818b5c229895b893318dcb87d2a65e557d4ebeb408b70"
 
       # Expected ECP2 (x, y: FP2) affine coordinates
-      let ecp = [
-        # x
-        "0x04861c41efcc5fc56e62273692b48da25d950d2a0aaffb34eff80e8dbdc2d41ca38555ceb8554368436aea47d16056b5",
-        "0x099695b4dc8d5dbebc73a9856cc859a3e5317e9a9e0459ee8fc03646bdcfe30125aa434dda228311f25d8c227d5eee289dd6a50897c08397565bc826c5c4113d",
-        # y
-        "177d05b95e7879a7ddbd83c15114b5a4e9846fde72b2263072dc9e60db548ccbadaacb92cc4952d4f47425fe3c5e0172",
-        "0fc82c99b928ed9df12a74f9215c3df8ae1e9a3fa54c00897889296890b23a0edcbb9653f9170bf715f882b35c0b4647"
-      ]
+      # x and y are complex coordinates in the form x' + iy'
+      # that satisfy the BLS12-384 equation: y² = x³ + 4
 
-      # TODO: doAssert the FP2
+      let ecp = toECP2(
+        x = hexToFP2(
+          # x = x' + iy'
+          x = "0x04861c41efcc5fc56e62273692b48da25d950d2a0aaffb34eff80e8dbdc2d41ca38555ceb8554368436aea47d16056b5",
+          y = "0x09db5217528c55d982cf05fc54242bdcd25f1ebb73372e00e16d8e0f19dc3aeabdeef2d42d693405a04c37d60961526a",
+        ),
+        y = hexToFP2(
+          # y = x'' + iy''
+          x = "0x177d05b95e7879a7ddbd83c15114b5a4e9846fde72b2263072dc9e60db548ccbadaacb92cc4952d4f47425fe3c5e0172",
+          y = "0x0fc82c99b928ed9df12a74f9215c3df8ae1e9a3fa54c00897889296890b23a0edcbb9653f9170bf715f882b35c0b4647"
+        )
+      )
 
-    testMapToCurveG2 PyECC_1:
+    testMapToCurveG2 PyECC_1_msg:
       # from hash_to_base_FP2("msg")
       let
         u0x = "0x18df4dc51885b18ca0082a4966b0def46287930b8f1c0b673b11ac48d19c8899bc150d83fd3a7a1430b0de541742c1d4"
@@ -535,43 +560,46 @@ when isMainModule:
         u1x = "0x14c81e3d32a930af141ff28f337e375bd7f2b35d006b2f6ba9a4c9eed7937e2b20d8b251fef776b0d497859510c9fad7"
         u1y = "0x05764cf5fe69554b971c5fe77eb3f3f9b89534547335b84ff02cd3d613bcd5e3037005b9226011a61a70b5bd0f0db570"
 
-      # Expected ECP2 (x, y: FP2) affine coordinates
-      let ecp = [
-        # x
-        "0x7896efdac56b0f6cbd8c78841676d63fc733b692628687bf25273aa8a107bd8cb53bbdb705b551e239dffe019abd4df",
-        "0xbd557eda8d16ab2cb2e71cca4d7b343985064daad04734e07da5cdda26610b59cdc0810a25276467d24b315bf7860e0",
-        # y
-        "0x1bdb6290cae9f30f263dd40f014b9f4406c3fbbc5fea47e2ebd45e42332553961eb53a15c09e5e090d7a7122dc6657",
-        "0x18370459c44e799af8ef31634a683e340e79c3a06f912594d287a443620933b47a2a3e5ce4470539eae50f6d49b8ebd6"
-      ]
-
-  # Test vectors for hashToG2
-  # ----------------------------------------------------------------------
-  # TODO, move to tests/ folder
-
-  template testHashToG2(id, constants: untyped) =
-    # https://github.com/mratsim/py_ecc/pull/1
-    proc `test _ id`() =
-      # We create a proc to avoid allocating too much globals.
-      constants
-
-      let pointG2 = hashToG2(msg, dst)
-      displayECP2Coord("PointG2", pointG2)
-
-    `test _ id`()
-
-  block: # hashToBaseFP2
-    testHashToG2 1:
-      let
-        msg = "msg"
-        dst = "BLS_SIG_BLS12381G2-SHA256-SSWU-RO_POP_"
-
-      # Expected output
-      let point = (
-        # x
-        ["0x7896efdac56b0f6cbd8c78841676d63fc733b692628687bf25273aa8a107bd8cb53bbdb705b551e239dffe019abd4df",
-         "0xbd557eda8d16ab2cb2e71cca4d7b343985064daad04734e07da5cdda26610b59cdc0810a25276467d24b315bf7860e0"],
-        # y
-        ["0x1bdb6290cae9f30f263dd40f014b9f4406c3fbbc5fea47e2ebd45e42332553961eb53a15c09e5e090d7a7122dc6657",
-         "18370459c44e799af8ef31634a683e340e79c3a06f912594d287a443620933b47a2a3e5ce4470539eae50f6d49b8ebd6"]
+      let ecp = toECP2(
+        x = hexToFP2(
+          # x = x' + iy'
+          x = "0x07896efdac56b0f6cbd8c78841676d63fc733b692628687bf25273aa8a107bd8cb53bbdb705b551e239dffe019abd4df",
+          y = "0x0bd557eda8d16ab2cb2e71cca4d7b343985064daad04734e07da5cdda26610b59cdc0810a25276467d24b315bf7860e0",
+        ),
+        y = hexToFP2(
+          # y = x'' + iy''
+          x = "0x001bdb6290cae9f30f263dd40f014b9f4406c3fbbc5fea47e2ebd45e42332553961eb53a15c09e5e090d7a7122dc6657",
+          y = "0x18370459c44e799af8ef31634a683e340e79c3a06f912594d287a443620933b47a2a3e5ce4470539eae50f6d49b8ebd6"
+        )
       )
+
+  # # Test vectors for hashToG2
+  # # ----------------------------------------------------------------------
+  # # TODO, move to tests/ folder
+
+  # template testHashToG2(id, constants: untyped) =
+  #   # https://github.com/mratsim/py_ecc/pull/1
+  #   proc `test _ id`() =
+  #     # We create a proc to avoid allocating too much globals.
+  #     constants
+
+  #     let pointG2 = hashToG2(msg, dst)
+  #     displayECP2Coord("PointG2", pointG2)
+
+  #   `test _ id`()
+
+  # block: # hashToBaseFP2
+  #   testHashToG2 1:
+  #     let
+  #       msg = "msg"
+  #       dst = "BLS_SIG_BLS12381G2-SHA256-SSWU-RO_POP_"
+
+  #     # Expected output
+  #     let point = (
+  #       # x
+  #       ["0x7896efdac56b0f6cbd8c78841676d63fc733b692628687bf25273aa8a107bd8cb53bbdb705b551e239dffe019abd4df",
+  #        "0xbd557eda8d16ab2cb2e71cca4d7b343985064daad04734e07da5cdda26610b59cdc0810a25276467d24b315bf7860e0"],
+  #       # y
+  #       ["0x1bdb6290cae9f30f263dd40f014b9f4406c3fbbc5fea47e2ebd45e42332553961eb53a15c09e5e090d7a7122dc6657",
+  #        "18370459c44e799af8ef31634a683e340e79c3a06f912594d287a443620933b47a2a3e5ce4470539eae50f6d49b8ebd6"]
+  #     )

--- a/blscurve/hash_to_curve.nim
+++ b/blscurve/hash_to_curve.nim
@@ -1,0 +1,226 @@
+# Nim-BLSCurve
+# Copyright (c) 2018-Present Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+# Hash to Elliptic curve implementation for BLS12-381.
+# - IETF Standard Draft: https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04
+#   - Algorithm description in section 8.7
+#   - This includes a specific appendix for BLS12-381 (Appendix C)
+# - IETF Implementation: https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve
+#   - The following can be used as a test vector generator:
+#     https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve/blob/6cf7fa97/poc/suite_bls12381g2.sage
+# - Ethereum Foundation implementation: https://github.com/ethereum/py_ecc
+#   - Specific PR: https://github.com/ethereum/py_ecc/pull/83/files
+
+# TODO: clarify the meaning of string / octet string / bit string
+#       the EF implementation appends a 0x00 byte to messages
+#       that does not exist in the IETF spec.
+
+# hash_to_curve
+# ----------------------------------------------------------------------
+# Section 3 - https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04#section-3
+#
+# This section presents a general framework for encoding bit strings to
+# points on an elliptic curve.  To construct these encodings, we rely
+# on three basic functions:
+#
+# o  The function hash_to_base, {0, 1}^* x {0, 1, 2} -> F, hashes
+#    arbitrary-length bit strings to elements of a finite field; its
+#    implementation is defined in Section 5.
+#
+# o  The function map_to_curve, F -> E, calculates a point on the
+#    elliptic curve E from an element of the finite field F over which
+#    E is defined.  Section 6 describes mappings for a range of curve
+#    families.
+#
+# o  The function clear_cofactor, E -> G, sends any point on the curve
+#    E to the subgroup G of E.  Section 7 describes methods to perform
+#    this operation.
+#
+# [...] (Overview of encode_to_curve)
+#
+# Random oracle encoding (hash_to_curve).
+#   This function encodes bitstrings to points in G.
+#   The distribution of the output is
+#   indistinguishable from uniformly random in G provided that
+#   map_to_curve is "well distributed" ([FFSTV13], Def. 1).  All of
+#   the map_to_curve functions defined in Section 6 meet this
+#   requirement.
+#
+#   hash_to_curve(alpha)
+#
+#   Input: alpha, an arbitrary-length bit string.
+#   Output: P, a point in G.
+#
+#   Steps:
+#   1. u0 = hash_to_base(alpha, 0)
+#   2. u1 = hash_to_base(alpha, 1)
+#   3. Q0 = map_to_curve(u0)
+#   4. Q1 = map_to_curve(u1)
+#   5. R = Q0 + Q1      // point addition
+#   6. P = clear_cofactor(R)
+#   7. return P
+#
+#   Instances of these functions are given in Section 8, which defines a
+#   list of suites that specify a full set of parameters matching
+#   elliptic curves and algorithms.
+
+# hash_to_base
+# ----------------------------------------------------------------------
+# Section 5.3 - https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04#section-5.3
+#
+# The following procedure implements hash_to_base.
+#
+# hash_to_base(msg, ctr)
+#
+# Parameters:
+# - DST, a domain separation tag (see discussion above).
+# - H, a cryptographic hash function.
+# - F, a finite field of characteristic p and order q = p^m.
+# - L = ceil((ceil(log2(p)) + k) / 8), where k is the security
+#   parameter of the cryptosystem (e.g., k = 128).
+# - HKDF-Extract and HKDF-Expand are as defined in RFC5869,
+#   instantiated with the hash function H.
+#
+# Inputs:
+# - msg is the message to hash.
+# - ctr is 0, 1, or 2.
+#   This is used to efficiently create independent
+#   instances of hash_to_base (see discussion above).
+#
+# Output:
+# - u, an element in F.
+#
+# Steps:
+# 1. m' = HKDF-Extract(DST, msg)
+# 2. for i in (1, ..., m):
+# 3.   info = "H2C" || I2OSP(ctr, 1) || I2OSP(i, 1)
+# 4.   t = HKDF-Expand(m', info, L)
+# 5.   e_i = OS2IP(t) mod p
+# 6. return u = (e_1, ..., e_m)
+#
+# Note:
+#   I2OSP and OS2IP: These primitives are used to convert an octet string to
+#   and from a non-negative integer as described in RFC8017.
+#   https://tools.ietf.org/html/rfc8017#section-4
+#
+#   In summary those are bigEndian <-> integer conversion with signatures
+#   - proc I2OSP(n: Natural, resultLen: Natural): string
+#   - proc OS2IP(s: string): Natural
+
+# Implementation
+# ----------------------------------------------------------------------
+
+import
+  # Status libraries
+  nimcrypto/hmac,
+  # Internal
+  ./milagro, ./hkdf, ./common
+
+func hashToBaseFP2[T](
+                   ctx: var HMAC[T],
+                   msg: ptr byte, msgLen: uint,
+                   ctr: range[0'i8 .. 2'i8],
+                   domainSepTag: ptr byte,
+                   domainSepTagLen: uint
+                  ): FP2_BLS381 =
+  ## Implementation of hash_to_base for the G2 curve of BLS12-381
+  ## https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04#section-5.3
+  ##
+  ## Inputs
+  ## - msg + msgLen: the message to hash
+  ## - ctr: 0, 1 or 2.
+  ##   Create independant instances of HKDF-Expand (random oracle)
+  ##   from the same HKDF-Extract pseudo-random key
+  ## - domainSepTag + domainSepTagLen: A domain separation tag (DST)
+  ##   that MUST include a protocol identification string
+  ##   SHOULD include a protocol version number.
+  ##
+  ## Outputs
+  ## - A point on FP2
+  ##
+  ## Temporary
+  ## - ctx: a HMAC["cryptographic-hash"] context, for example HMAC[sha256].
+  #
+  # Note: ctr and domainSepTag are known at compile-time
+  #       however having them "static" would duplicate/quadruplicate code
+  #       with probably negligible performance improvement.
+
+  const
+    L_BLS = 64 # ceil((ceil(log2(p)) + k) / 8), where k is the security
+               # parameter of the cryptosystem (e.g., k = 128)
+    m = 2      # Extension degree of FP2
+
+  var
+    e1, e2: BIG_384
+    mprime: MDigest[T.bits]
+    info: array[5, byte]
+    t: array[L_BLS, byte]
+
+  # TODO: assert ending by 0x00 byte?
+  hkdfExtract(ctx, mprime, domainSepTag, domainSepTagLen, msg, msgLen)
+
+  info[0] = ord'H'
+  info[1] = ord'2'
+  info[2] = ord'C'
+  info[3] = byte(ctr)
+
+  template loopIter(ei: untyped, i: range[1..m]): untyped {.dirty.} =
+    ## for i in 1 .. m
+    ## with m = 2 (extension degree of FP2)
+    info[4] = byte(i)
+    hkdfExpand(ctx, mprime, info[0].addr, info.len.uint, t[0].addr, t.len.uint)
+    discard fromBytes(ei, t)
+
+  loopIter(e1, 1)
+  loopIter(e2, 2)
+
+  result.fromBigs(e1, e2)
+
+# Unofficial test vectors for hashToG2 primitives
+# ----------------------------------------------------------------------
+# https://github.com/mratsim/py_ecc/pull/1
+
+when isMainModule:
+  import stew/byteutils, nimcrypto/[sha2, hmac]
+
+  proc hexToBytes(s: string): seq[byte] =
+    if s.len != 0: return hexToSeqByte(s)
+
+  template testHashToBaseFP2(id, constants: untyped) =
+    proc `test _ id`() =
+      # We create a proc to avoid allocating too much globals.
+      constants
+
+      let pmsg = if msg.len == 0: nil
+                 else: cast[ptr byte](msg[0].unsafeAddr)
+      let pdst = cast[ptr byte](dst[0].unsafeAddr)
+
+      var ctx: HMAC[sha256]
+      # Important: do we need to include the null byte at the end?
+      let pointG2 = hashToBaseFP2(
+        ctx,
+        pmsg, msg.len.uint + 1,
+        ctr,
+        pdst, dst.len.uint
+      )
+      echo pointG2
+
+    `test _ id`()
+
+  block: # hashToBaseFP2
+    testHashToBaseFP2 1:
+      let
+        msg = "msg"
+        ctr = 0'i8
+        dst = "BLS_SIG_BLS12381G2-SHA256-SSWU-RO_POP_"
+
+      let e = [
+        "0x3852c6c62ecd4e04360c24e8ddeac03661b07575a60d6fb7b0a90ce0bb7c7667624fbeea77777e52099dd43356e03192b3d4d27264fd09d0afadda24f48b6f2c",
+        "0x099695b4dc8d5dbebc73a9856cc859a3e5317e9a9e0459ee8fc03646bdcfe30125aa434dda228311f25d8c227d5eee289dd6a50897c08397565bc826c5c4113d"
+      ]

--- a/blscurve/hash_to_curve.nim
+++ b/blscurve/hash_to_curve.nim
@@ -545,8 +545,9 @@ when isMainModule:
       var P = q0
       P.add(q1)
 
+      displayECP2Coord("P (before clearCofactor)", P)
       P.clearCofactor()
-      # displayECP2Coord("P", P)
+      displayECP2Coord("P (after clearCofactor)", P)
 
       doAssert P == ecp
       echo "Success mapToCurveG2 ", astToStr(id)

--- a/blscurve/hash_to_curve.nim
+++ b/blscurve/hash_to_curve.nim
@@ -118,6 +118,16 @@ proc toFP2(x, y: uint64): FP2_BLS381 =
 
   result.fromBigs(xBig, yBig)
 
+proc hexToFP2(x, y: string): FP2_BLS381 =
+  ## Convert a complex tuple x + iy to FP2
+  # TODO: the result does not seem to need zero-initialization
+  var xBig, yBig: BIG_384
+
+  discard xBig.fromHex(x)
+  discard yBig.fromHex(y)
+
+  result.fromBigs(xBig, yBig)
+
 proc isSquare(a: FP2_BLS381): bool =
   ## Returns true if ``a`` is a square in the FP2 field
   ## This is NOT a constant-time operation (Milagro has branches)
@@ -144,9 +154,10 @@ proc isNeg(a: FP2_BLS381): bool =
   let neg = neg(a)
   result = cmp(a, neg) < 0
 
-func mapToCurveSimpleSWU_G2(u: FP2_BLS381): ECP2_BLS381 =
+func mapToIsoCurveSimpleSWU_G2(u: FP2_BLS381): ECP2_BLS381 =
   ## Implementation of map_to_curve_simple_swu
-  ## for the G2 curve of BLS12-381 curve.
+  ## to map an element of FP2 to a curve isogenous
+  ## to the G2 curve of BLS12-381 curve.
   ##
   ## SWU stands for Shallue-van de Woestijne-Ulas mapping
   ## described in https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04#section-6.5.2
@@ -155,7 +166,7 @@ func mapToCurveSimpleSWU_G2(u: FP2_BLS381): ECP2_BLS381 =
   ## - u, an element of FP2
   ##
   ## Output:
-  ## - (x, y), a point on G2
+  ## - (x, y), a point on G'2, a curve isogenous to G2 curve of BLS12-381
 
   {.noSideEffect.}: # Only globals accessed are A, B, Z, c1, c2.
                     # we use globals to ensure they are computed only once.
@@ -198,6 +209,70 @@ func mapToCurveSimpleSWU_G2(u: FP2_BLS381): ECP2_BLS381 =
 
   let onCurve = bool ECP2_BLS381_set(addr result, unsafeAddr x, unsafeAddr y)
   assert onCurve
+
+proc isogeny_map_G2(isoPoint: ECP2_BLS381): ECP2_BLS381 =
+  ## 3-isogeny map from a point P' (x', y') on G'2
+  ## to a point P(x, y) on G2 curve of BLS12-381.
+  ##
+  ## https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-05#appendix-C.3
+
+  {.noSideEffect.}: # Globals to ensure they are computed only once
+    # Constants to compute x_numerator
+    let k10 {.global.} = hexToFP2(
+      "0x5c759507e8e333ebb5b7a9a47d7ed8532c52d39fd3a042a88b58423c50ae15d5c2638e343d9c71c6238aaaaaaaa97d6",
+      "0x5c759507e8e333ebb5b7a9a47d7ed8532c52d39fd3a042a88b58423c50ae15d5c2638e343d9c71c6238aaaaaaaa97d6"
+    )
+    let k11 {.global.} = hexToFP2(
+      "0x0",
+      "0x11560bf17baa99bc32126fced787c88f984f87adf7ae0c7f9a208c6b4f20a4181472aaa9cb8d555526a9ffffffffc71a"
+    )
+    let k12 {.global.} = hexToFP2( # The last nibble "e" is not a typo
+      "0x11560bf17baa99bc32126fced787c88f984f87adf7ae0c7f9a208c6b4f20a4181472aaa9cb8d555526a9ffffffffc71e",
+      "0x8ab05f8bdd54cde190937e76bc3e447cc27c3d6fbd7063fcd104635a790520c0a395554e5c6aaaa9354ffffffffe38d"
+    )
+    let k13 {.global.} = hexToFP2(
+      "0x171d6541fa38ccfaed6dea691f5fb614cb14b4e7f4e810aa22d6108f142b85757098e38d0f671c7188e2aaaaaaaa5ed1",
+      "0x0"
+    )
+    # Constants to compute x_denominator
+    let k20 {.global.} = hexToFP2(
+      "0x0",
+      "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa63"
+    )
+    let k21 {.global.} = hexToFP2( # the last byte "9f" is not a typo
+      "0xc",
+      "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa9f"
+    )
+    # Constants to compute y_numerator
+    let k30 {.global.} = hexToFP2(
+      "0x1530477c7ab4113b59a4c18b076d11930f7da5d4a07f649bf54439d87d27e500fc8c25ebf8c92f6812cfc71c71c6d706",
+      "0x1530477c7ab4113b59a4c18b076d11930f7da5d4a07f649bf54439d87d27e500fc8c25ebf8c92f6812cfc71c71c6d706"
+    )
+    let k31 {.global.} = hexToFP2(
+      "0x0",
+      "0x5c759507e8e333ebb5b7a9a47d7ed8532c52d39fd3a042a88b58423c50ae15d5c2638e343d9c71c6238aaaaaaaa97be"
+    )
+    let k32 {.global.} = hexToFP2(
+      "0x11560bf17baa99bc32126fced787c88f984f87adf7ae0c7f9a208c6b4f20a4181472aaa9cb8d555526a9ffffffffc71c",
+      "0x8ab05f8bdd54cde190937e76bc3e447cc27c3d6fbd7063fcd104635a790520c0a395554e5c6aaaa9354ffffffffe38f"
+    )
+    let k33 {.global.} = hexToFP2(
+      "0x124c9ad43b6cf79bfbf7043de3811ad0761b0f37a1e26286b0e977c69aa274524e79097a56dc4bd9e1b371c71c718b10",
+      "0x0"
+    )
+    # Constants to compute y_denominator
+    let k40 = hexToFP2(
+      "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa8fb",
+      "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa8fb"
+    )
+    let k41 = hexToFP2(
+      "0x0",
+      "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa9d3"
+    )
+    let k42 = hexToFP2(
+      "0x12",
+      "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa99"
+    )
 
 # Unofficial test vectors for hashToG2 primitives
 # ----------------------------------------------------------------------

--- a/blscurve/hash_to_curve.nim
+++ b/blscurve/hash_to_curve.nim
@@ -17,101 +17,9 @@
 # - Ethereum Foundation implementation: https://github.com/ethereum/py_ecc
 #   - Specific PR: https://github.com/ethereum/py_ecc/pull/83/files
 
-# TODO: clarify the meaning of string / octet string / bit string
-#       the EF implementation appends a 0x00 byte to messages
-#       that does not exist in the IETF spec.
-
-# hash_to_curve
-# ----------------------------------------------------------------------
-# Section 3 - https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04#section-3
-#
-# This section presents a general framework for encoding bit strings to
-# points on an elliptic curve.  To construct these encodings, we rely
-# on three basic functions:
-#
-# o  The function hash_to_base, {0, 1}^* x {0, 1, 2} -> F, hashes
-#    arbitrary-length bit strings to elements of a finite field; its
-#    implementation is defined in Section 5.
-#
-# o  The function map_to_curve, F -> E, calculates a point on the
-#    elliptic curve E from an element of the finite field F over which
-#    E is defined.  Section 6 describes mappings for a range of curve
-#    families.
-#
-# o  The function clear_cofactor, E -> G, sends any point on the curve
-#    E to the subgroup G of E.  Section 7 describes methods to perform
-#    this operation.
-#
-# [...] (Overview of encode_to_curve)
-#
-# Random oracle encoding (hash_to_curve).
-#   This function encodes bitstrings to points in G.
-#   The distribution of the output is
-#   indistinguishable from uniformly random in G provided that
-#   map_to_curve is "well distributed" ([FFSTV13], Def. 1).  All of
-#   the map_to_curve functions defined in Section 6 meet this
-#   requirement.
-#
-#   hash_to_curve(alpha)
-#
-#   Input: alpha, an arbitrary-length bit string.
-#   Output: P, a point in G.
-#
-#   Steps:
-#   1. u0 = hash_to_base(alpha, 0)
-#   2. u1 = hash_to_base(alpha, 1)
-#   3. Q0 = map_to_curve(u0)
-#   4. Q1 = map_to_curve(u1)
-#   5. R = Q0 + Q1      // point addition
-#   6. P = clear_cofactor(R)
-#   7. return P
-#
-#   Instances of these functions are given in Section 8, which defines a
-#   list of suites that specify a full set of parameters matching
-#   elliptic curves and algorithms.
-
-# hash_to_base
-# ----------------------------------------------------------------------
-# Section 5.3 - https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04#section-5.3
-#
-# The following procedure implements hash_to_base.
-#
-# hash_to_base(msg, ctr)
-#
-# Parameters:
-# - DST, a domain separation tag (see discussion above).
-# - H, a cryptographic hash function.
-# - F, a finite field of characteristic p and order q = p^m.
-# - L = ceil((ceil(log2(p)) + k) / 8), where k is the security
-#   parameter of the cryptosystem (e.g., k = 128).
-# - HKDF-Extract and HKDF-Expand are as defined in RFC5869,
-#   instantiated with the hash function H.
-#
-# Inputs:
-# - msg is the message to hash.
-# - ctr is 0, 1, or 2.
-#   This is used to efficiently create independent
-#   instances of hash_to_base (see discussion above).
-#
-# Output:
-# - u, an element in F.
-#
-# Steps:
-# 1. m' = HKDF-Extract(DST, msg)
-# 2. for i in (1, ..., m):
-# 3.   info = "H2C" || I2OSP(ctr, 1) || I2OSP(i, 1)
-# 4.   t = HKDF-Expand(m', info, L)
-# 5.   e_i = OS2IP(t) mod p
-# 6. return u = (e_1, ..., e_m)
-#
-# Note:
-#   I2OSP and OS2IP: These primitives are used to convert an octet string to
-#   and from a non-negative integer as described in RFC8017.
-#   https://tools.ietf.org/html/rfc8017#section-4
-#
-#   In summary those are bigEndian <-> integer conversion with signatures
-#   - proc I2OSP(n: Natural, resultLen: Natural): string
-#   - proc OS2IP(s: string): Natural
+# This file has a companion markdown file with the relevant part of the standard.
+# Important: the standard seem to assume that strings are 0x00 terminated
+#            and that that null bytes is part of the hashed message.
 
 # Implementation
 # ----------------------------------------------------------------------
@@ -134,6 +42,7 @@ func hashToBaseFP2[T](
   ##
   ## Inputs
   ## - msg + msgLen: the message to hash
+  ##   msg[msgLen] should be the null byte 0x00
   ## - ctr: 0, 1 or 2.
   ##   Create independant instances of HKDF-Expand (random oracle)
   ##   from the same HKDF-Extract pseudo-random key
@@ -162,7 +71,7 @@ func hashToBaseFP2[T](
     info: array[5, byte]
     t: array[L_BLS, byte]
 
-  # TODO: assert ending by 0x00 byte?
+  assert cast[ptr UncheckedArray[byte]](msg)[msgLen] == 0x00
   hkdfExtract(ctx, mprime, domainSepTag, domainSepTagLen, msg, msgLen)
 
   info[0] = ord'H'
@@ -175,7 +84,9 @@ func hashToBaseFP2[T](
     ## with m = 2 (extension degree of FP2)
     info[4] = byte(i)
     hkdfExpand(ctx, mprime, info[0].addr, info.len.uint, t[0].addr, t.len.uint)
+    # debugecho "t: ", t.toHex()
     discard fromBytes(ei, t)
+    # TODO: is field element normalization needed?
 
   loopIter(e1, 1)
   loopIter(e2, 2)
@@ -184,7 +95,6 @@ func hashToBaseFP2[T](
 
 # Unofficial test vectors for hashToG2 primitives
 # ----------------------------------------------------------------------
-# https://github.com/mratsim/py_ecc/pull/1
 
 when isMainModule:
   import stew/byteutils, nimcrypto/[sha2, hmac]
@@ -193,6 +103,7 @@ when isMainModule:
     if s.len != 0: return hexToSeqByte(s)
 
   template testHashToBaseFP2(id, constants: untyped) =
+    # https://github.com/mratsim/py_ecc/pull/1
     proc `test _ id`() =
       # We create a proc to avoid allocating too much globals.
       constants
@@ -203,13 +114,13 @@ when isMainModule:
 
       var ctx: HMAC[sha256]
       # Important: do we need to include the null byte at the end?
-      let pointG2 = hashToBaseFP2(
+      let pointFP2 = hashToBaseFP2(
         ctx,
         pmsg, msg.len.uint + 1,
         ctr,
         pdst, dst.len.uint
       )
-      echo pointG2
+      echo pointFP2
 
     `test _ id`()
 
@@ -220,7 +131,8 @@ when isMainModule:
         ctr = 0'i8
         dst = "BLS_SIG_BLS12381G2-SHA256-SSWU-RO_POP_"
 
-      let e = [
+      # Expected output after hkdfExpand
+      let t = [
         "0x3852c6c62ecd4e04360c24e8ddeac03661b07575a60d6fb7b0a90ce0bb7c7667624fbeea77777e52099dd43356e03192b3d4d27264fd09d0afadda24f48b6f2c",
         "0x099695b4dc8d5dbebc73a9856cc859a3e5317e9a9e0459ee8fc03646bdcfe30125aa434dda228311f25d8c227d5eee289dd6a50897c08397565bc826c5c4113d"
       ]

--- a/blscurve/hash_to_curve.nim
+++ b/blscurve/hash_to_curve.nim
@@ -8,7 +8,7 @@
 # those terms.
 
 # Hash to Elliptic curve implementation for BLS12-381.
-# - IETF Standard Draft: https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04
+# - IETF Standard Draft: https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-05
 #   - Algorithm description in section 8.7
 #   - This includes a specific appendix for BLS12-381 (Appendix C)
 # - IETF Implementation: https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve
@@ -572,34 +572,3 @@ when isMainModule:
           y = "0x18370459c44e799af8ef31634a683e340e79c3a06f912594d287a443620933b47a2a3e5ce4470539eae50f6d49b8ebd6"
         )
       )
-
-  # # Test vectors for hashToG2
-  # # ----------------------------------------------------------------------
-  # # TODO, move to tests/ folder
-
-  # template testHashToG2(id, constants: untyped) =
-  #   # https://github.com/mratsim/py_ecc/pull/1
-  #   proc `test _ id`() =
-  #     # We create a proc to avoid allocating too much globals.
-  #     constants
-
-  #     let pointG2 = hashToG2(msg, dst)
-  #     displayECP2Coord("PointG2", pointG2)
-
-  #   `test _ id`()
-
-  # block: # hashToBaseFP2
-  #   testHashToG2 1:
-  #     let
-  #       msg = "msg"
-  #       dst = "BLS_SIG_BLS12381G2-SHA256-SSWU-RO_POP_"
-
-  #     # Expected output
-  #     let point = (
-  #       # x
-  #       ["0x7896efdac56b0f6cbd8c78841676d63fc733b692628687bf25273aa8a107bd8cb53bbdb705b551e239dffe019abd4df",
-  #        "0xbd557eda8d16ab2cb2e71cca4d7b343985064daad04734e07da5cdda26610b59cdc0810a25276467d24b315bf7860e0"],
-  #       # y
-  #       ["0x1bdb6290cae9f30f263dd40f014b9f4406c3fbbc5fea47e2ebd45e42332553961eb53a15c09e5e090d7a7122dc6657",
-  #        "18370459c44e799af8ef31634a683e340e79c3a06f912594d287a443620933b47a2a3e5ce4470539eae50f6d49b8ebd6"]
-  #     )

--- a/blscurve/hash_to_curve.nim
+++ b/blscurve/hash_to_curve.nim
@@ -388,6 +388,8 @@ when isMainModule:
   proc hexToBytes(s: string): seq[byte] =
     if s.len != 0: return hexToSeqByte(s)
 
+  # Test vectors for hashToBaseFP2
+  # ----------------------------------------------------------------------
   template testHashToBaseFP2(id, constants: untyped) =
     # https://github.com/mratsim/py_ecc/pull/1
     proc `test _ id`() =
@@ -410,17 +412,67 @@ when isMainModule:
 
     `test _ id`()
 
-  block: # hashToBaseFP2
-    testHashToBaseFP2 1:
-      let
-        msg = "msg"
-        ctr = 0'i8
-        dst = "BLS_SIG_BLS12381G2-SHA256-SSWU-RO_POP_"
+  # block: # hashToBaseFP2
+  #   testHashToBaseFP2 1:
+  #     let
+  #       msg = "msg"
+  #       ctr = 0'i8
+  #       dst = "BLS_SIG_BLS12381G2-SHA256-SSWU-RO_POP_"
 
-      # Expected output after hkdfExpand
-      let t = [
-        "0x3852c6c62ecd4e04360c24e8ddeac03661b07575a60d6fb7b0a90ce0bb7c7667624fbeea77777e52099dd43356e03192b3d4d27264fd09d0afadda24f48b6f2c",
-        "0x099695b4dc8d5dbebc73a9856cc859a3e5317e9a9e0459ee8fc03646bdcfe30125aa434dda228311f25d8c227d5eee289dd6a50897c08397565bc826c5c4113d"
+  #     # Expected output after hkdfExpand
+  #     let t = [
+  #       "0x3852c6c62ecd4e04360c24e8ddeac03661b07575a60d6fb7b0a90ce0bb7c7667624fbeea77777e52099dd43356e03192b3d4d27264fd09d0afadda24f48b6f2c",
+  #       "0x099695b4dc8d5dbebc73a9856cc859a3e5317e9a9e0459ee8fc03646bdcfe30125aa434dda228311f25d8c227d5eee289dd6a50897c08397565bc826c5c4113d"
+  #     ]
+
+  #     # TODO: doAssert the FP2
+
+  # Test vectors for mapToCurveG2
+  # ----------------------------------------------------------------------
+  template testMapToCurveG2(id, constants: untyped) =
+    # https://github.com/sigp/incubator-milagro-crypto-rust/blob/49563467/src/bls381.rs#L209-L328
+    # Themselves extracted from
+    # https://github.com/kwantam/bls_sigs_ref/tree/master/python-impl
+    proc `test _ id`() =
+      # We create a proc to avoid allocating too much globals.
+      constants
+
+      let u0 = hexToFP2(u0x, u0y)
+      let u1 = hexToFP2(u1x, u1y)
+
+      echo "-----------------------------------"
+      echo "u0: ", u0
+      FP2_BLS381_output(u0.unsafeAddr)
+      echo "\nu1: ", u1
+      FP2_BLS381_output(u1.unsafeAddr)
+      echo ""
+
+
+      let q0 = mapToCurveG2(u0)
+      let q1 = mapToCurveG2(u1)
+
+      echo "-----------------------------------"
+      echo "q0: ", q0
+      echo "q1: ", q1
+
+    `test _ id`()
+
+  block: # hashToBaseFP2
+    testMapToCurveG2 1:
+      let
+        u0x = "0x004ad233c619209060e40059b81e4c1f92796b05aa1bc6358d65e53dc0d657dfbc713d4030b0b6d9234a6634fd1944e7"
+        u0y = "0x0e2386c82713441bc3b06a460bd81850f4bf376ea89c80b18c0881e855c58dc8e83b2fd23af983f4786508e30c42af01"
+        u1x = "0x08a6a75e0a8d32f1e096f29047ea879dd34a5504218d7ce92c32c244786822fb73fbf708d167ad86537468249ec6df48"
+        u1y = "0x07016d0e5e13cd65780042c6f7b4c74ae1c58da438c99582696818b5c229895b893318dcb87d2a65e557d4ebeb408b70"
+
+      # Expected ECP2 (x, y: FP2) affine coordinates
+      let ecp = [
+        # x
+        "0x04861c41efcc5fc56e62273692b48da25d950d2a0aaffb34eff80e8dbdc2d41ca38555ceb8554368436aea47d16056b5",
+        "0x099695b4dc8d5dbebc73a9856cc859a3e5317e9a9e0459ee8fc03646bdcfe30125aa434dda228311f25d8c227d5eee289dd6a50897c08397565bc826c5c4113d",
+        # y
+        "177d05b95e7879a7ddbd83c15114b5a4e9846fde72b2263072dc9e60db548ccbadaacb92cc4952d4f47425fe3c5e0172",
+        "0fc82c99b928ed9df12a74f9215c3df8ae1e9a3fa54c00897889296890b23a0edcbb9653f9170bf715f882b35c0b4647"
       ]
 
       # TODO: doAssert the FP2
@@ -445,18 +497,18 @@ when isMainModule:
 
     `test _ id`()
 
-  block: # hashToBaseFP2
-    testHashToG2 1:
-      let
-        msg = "msg"
-        dst = "BLS_SIG_BLS12381G2-SHA256-SSWU-RO_POP_"
+  # block: # hashToBaseFP2
+  #   testHashToG2 1:
+  #     let
+  #       msg = "msg"
+  #       dst = "BLS_SIG_BLS12381G2-SHA256-SSWU-RO_POP_"
 
-      # Expected output
-      let point = (
-        # x
-        ["0x7896efdac56b0f6cbd8c78841676d63fc733b692628687bf25273aa8a107bd8cb53bbdb705b551e239dffe019abd4df",
-         "0xbd557eda8d16ab2cb2e71cca4d7b343985064daad04734e07da5cdda26610b59cdc0810a25276467d24b315bf7860e0"],
-        # y
-        ["0x1bdb6290cae9f30f263dd40f014b9f4406c3fbbc5fea47e2ebd45e42332553961eb53a15c09e5e090d7a7122dc6657",
-         "18370459c44e799af8ef31634a683e340e79c3a06f912594d287a443620933b47a2a3e5ce4470539eae50f6d49b8ebd6"]
-      )
+  #     # Expected output
+  #     let point = (
+  #       # x
+  #       ["0x7896efdac56b0f6cbd8c78841676d63fc733b692628687bf25273aa8a107bd8cb53bbdb705b551e239dffe019abd4df",
+  #        "0xbd557eda8d16ab2cb2e71cca4d7b343985064daad04734e07da5cdda26610b59cdc0810a25276467d24b315bf7860e0"],
+  #       # y
+  #       ["0x1bdb6290cae9f30f263dd40f014b9f4406c3fbbc5fea47e2ebd45e42332553961eb53a15c09e5e090d7a7122dc6657",
+  #        "18370459c44e799af8ef31634a683e340e79c3a06f912594d287a443620933b47a2a3e5ce4470539eae50f6d49b8ebd6"]
+  #     )

--- a/blscurve/hash_to_curve.nim
+++ b/blscurve/hash_to_curve.nim
@@ -108,7 +108,7 @@ func hashToBaseFP2[T](
 
   result.fromBigs(e1, e2)
 
-proc toFP2(x, y: uint64): FP2_BLS381 =
+func toFP2(x, y: uint64): FP2_BLS381 =
   ## Convert a complex tuple x + iy to FP2
   # TODO: the result does not seem to need zero-initialization
   var xBig, yBig: BIG_384
@@ -118,7 +118,7 @@ proc toFP2(x, y: uint64): FP2_BLS381 =
 
   result.fromBigs(xBig, yBig)
 
-proc hexToFP2(x, y: string): FP2_BLS381 =
+func hexToFP2(x, y: string): FP2_BLS381 =
   ## Convert a complex tuple x + iy to FP2
   # TODO: the result does not seem to need zero-initialization
   var xBig, yBig: BIG_384
@@ -128,7 +128,7 @@ proc hexToFP2(x, y: string): FP2_BLS381 =
 
   result.fromBigs(xBig, yBig)
 
-proc isSquare(a: FP2_BLS381): bool =
+func isSquare(a: FP2_BLS381): bool =
   ## Returns true if ``a`` is a square in the FP2 field
   ## This is NOT a constant-time operation (Milagro has branches)
 
@@ -146,7 +146,7 @@ proc isSquare(a: FP2_BLS381): bool =
   var tmp: FP2_BLS381
   result = sqrt(tmp, a)
 
-proc isNeg(a: FP2_BLS381): bool =
+func isNeg(a: FP2_BLS381): bool =
   ## Returns the "negative sign" (mod q) of a value
   ## a is negative when a (mod q) > -a (mod q)
   ## https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-05#section-4.1.1
@@ -210,7 +210,7 @@ func mapToIsoCurveSimpleSWU_G2(u: FP2_BLS381): tuple[x, y: FP2_BLS381] =
   result.x = x
   result.y = y
 
-proc isogeny_map_G2(xp, yp: FP2_BLS381): ECP2_BLS381 =
+func isogeny_map_G2(xp, yp: FP2_BLS381): ECP2_BLS381 =
   ## 3-isogeny map from a point P' (x', y') on G'2
   ## to a point P(x, y) on G2 curve of BLS12-381.
   ##
@@ -219,28 +219,28 @@ proc isogeny_map_G2(xp, yp: FP2_BLS381): ECP2_BLS381 =
   {.noSideEffect.}: # Globals to ensure they are computed only once
     # Constants to compute x_numerator
     let k10 {.global.} = hexToFP2(
-      "0x5c759507e8e333ebb5b7a9a47d7ed8532c52d39fd3a042a88b58423c50ae15d5c2638e343d9c71c6238aaaaaaaa97d6",
-      "0x5c759507e8e333ebb5b7a9a47d7ed8532c52d39fd3a042a88b58423c50ae15d5c2638e343d9c71c6238aaaaaaaa97d6"
+      "0x05c759507e8e333ebb5b7a9a47d7ed8532c52d39fd3a042a88b58423c50ae15d5c2638e343d9c71c6238aaaaaaaa97d6",
+      "0x05c759507e8e333ebb5b7a9a47d7ed8532c52d39fd3a042a88b58423c50ae15d5c2638e343d9c71c6238aaaaaaaa97d6"
     )
     let k11 {.global.} = hexToFP2(
-      "0x0",
+      "0x00",
       "0x11560bf17baa99bc32126fced787c88f984f87adf7ae0c7f9a208c6b4f20a4181472aaa9cb8d555526a9ffffffffc71a"
     )
     let k12 {.global.} = hexToFP2( # The last nibble "e" is not a typo
       "0x11560bf17baa99bc32126fced787c88f984f87adf7ae0c7f9a208c6b4f20a4181472aaa9cb8d555526a9ffffffffc71e",
-      "0x8ab05f8bdd54cde190937e76bc3e447cc27c3d6fbd7063fcd104635a790520c0a395554e5c6aaaa9354ffffffffe38d"
+      "0x08ab05f8bdd54cde190937e76bc3e447cc27c3d6fbd7063fcd104635a790520c0a395554e5c6aaaa9354ffffffffe38d"
     )
     let k13 {.global.} = hexToFP2(
       "0x171d6541fa38ccfaed6dea691f5fb614cb14b4e7f4e810aa22d6108f142b85757098e38d0f671c7188e2aaaaaaaa5ed1",
-      "0x0"
+      "0x00"
     )
     # Constants to compute x_denominator
     let k20 {.global.} = hexToFP2(
-      "0x0",
+      "0x00",
       "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa63"
     )
     let k21 {.global.} = hexToFP2( # the last byte "9f" is not a typo
-      "0xc",
+      "0x0c",
       "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa9f"
     )
     # Constants to compute y_numerator
@@ -249,16 +249,16 @@ proc isogeny_map_G2(xp, yp: FP2_BLS381): ECP2_BLS381 =
       "0x1530477c7ab4113b59a4c18b076d11930f7da5d4a07f649bf54439d87d27e500fc8c25ebf8c92f6812cfc71c71c6d706"
     )
     let k31 {.global.} = hexToFP2(
-      "0x0",
-      "0x5c759507e8e333ebb5b7a9a47d7ed8532c52d39fd3a042a88b58423c50ae15d5c2638e343d9c71c6238aaaaaaaa97be"
+      "0x00",
+      "0x05c759507e8e333ebb5b7a9a47d7ed8532c52d39fd3a042a88b58423c50ae15d5c2638e343d9c71c6238aaaaaaaa97be"
     )
     let k32 {.global.} = hexToFP2(
       "0x11560bf17baa99bc32126fced787c88f984f87adf7ae0c7f9a208c6b4f20a4181472aaa9cb8d555526a9ffffffffc71c",
-      "0x8ab05f8bdd54cde190937e76bc3e447cc27c3d6fbd7063fcd104635a790520c0a395554e5c6aaaa9354ffffffffe38f"
+      "0x08ab05f8bdd54cde190937e76bc3e447cc27c3d6fbd7063fcd104635a790520c0a395554e5c6aaaa9354ffffffffe38f"
     )
     let k33 {.global.} = hexToFP2(
       "0x124c9ad43b6cf79bfbf7043de3811ad0761b0f37a1e26286b0e977c69aa274524e79097a56dc4bd9e1b371c71c718b10",
-      "0x0"
+      "0x00"
     )
     # Constants to compute y_denominator
     let k40 = hexToFP2(
@@ -266,7 +266,7 @@ proc isogeny_map_G2(xp, yp: FP2_BLS381): ECP2_BLS381 =
       "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa8fb"
     )
     let k41 = hexToFP2(
-      "0x0",
+      "0x00",
       "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa9d3"
     )
     let k42 = hexToFP2(
@@ -324,6 +324,61 @@ proc isogeny_map_G2(xp, yp: FP2_BLS381): ECP2_BLS381 =
   let onCurve = bool ECP2_BLS381_set(addr result, unsafeAddr x, unsafeAddr y)
   assert onCurve
 
+func mapToCurveG2(u: FP2_BLS381): ECP2_BLS381 =
+  ## Map a field element FP2 to the G2 curve of BLS12-381
+  ## using the simplified SWU method for pairing-friendly curves
+  ##
+  ## SWU stands for Shallue-van de Woestijne-Ulas
+  ## Described in https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04#section-6.9.2
+  ## And
+  ## Wahby, R. and D. Boneh,
+  ## "Fast and simple constant-time hashing to the BLS12-381 elliptic curve"
+  ## https://eprint.iacr.org/2019/403
+
+  # Hash to a curve isogenous to G2 BLS12-381
+  let pointPrime = mapToIsoCurveSimpleSWU_G2(u)
+  # 3-isogeny map P'(x', y') to G2 with coordinate P(x, y)
+  result = isogeny_map_G2(pointPrime.x, pointPrime.y)
+
+func clearCofactor(P: ECP2_BLS381): ECP2_BLS381 =
+  ## From any point on the elliptic curve of G2 of BLS12-381
+  ## Obtain a point in the G2 subgroup
+  ##
+  ## Described in https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-05#section-7
+  #
+  # Implementations, multiple implementations are possible in decreasing order of speed:
+  #
+  # - The default, canonical, implementation is h_eff * P
+  # - Scott et al, "Fast Hashing to G2 on Pairing-Friendly Curves", https://doi.org/10.1007/978-3-642-03298-1_8
+  # - Fuentes-Castaneda et al, "Fast Hashing to G2 on Pairing-Friendly Curves", https://doi.org/10.1007/978-3-642-28496-0_25
+  # - Budroni et al, "Hashing to G2 on BLS pairing-friendly curves", https://doi.org/10.1145/3313880.3313884
+  # - Wahby et al "Fast and simple constant-time hashing to the BLS12-381 elliptic curve", https://eprint.iacr.org/2019/403
+  mulCoFactor(P)
+
+func hashToG2*(message, domainSepTag: string): ECP2_BLS381 =
+  ## Hash an arbitrary message to the G2 curve of BLS12-381
+  ## The message should have an extra null byte
+  # TODO: an API for strings (which are null-terminated)
+  #       and an API for raw bytes which needs extra allocation
+  # TODO: API should use ptr+len to bytes
+  # TODO: handle empty messages in constant-time
+  var ctx: HMAC[sha256]
+  let
+    pmsg = cast[ptr byte](message[0].unsafeAddr)
+    msgLen = message.len.uint
+    pdst = cast[ptr byte](domainSepTag[0].unsafeAddr)
+    dstLen = domainSepTag.len.uint
+
+    u0 = hashToBaseFP2(ctx, pmsg, msgLen, ctr = 0, pdst, dstLen)
+    u1 = hashToBaseFP2(ctx, pmsg, msgLen, ctr = 1, pdst, dstLen)
+    Q0 = mapToCurveG2(u0)
+    Q1 = mapToCurveG2(u1)
+
+  var R = Q0
+  R.add(Q1)
+
+  result = clearCofactor(R)
+
 # Unofficial test vectors for hashToG2 primitives
 # ----------------------------------------------------------------------
 
@@ -369,3 +424,39 @@ when isMainModule:
       ]
 
       # TODO: doAssert the FP2
+
+  # Test vectors for hashToG2
+  # ----------------------------------------------------------------------
+  # TODO, move to tests/ folder
+
+  template testHashToG2(id, constants: untyped) =
+    # https://github.com/mratsim/py_ecc/pull/1
+    proc `test _ id`() =
+      # We create a proc to avoid allocating too much globals.
+      constants
+
+      let pointG2 = hashToG2(msg, dst)
+      echo "In projective coordinate (x, y, z)"
+      echo pointG2
+      echo "In Affine coordinate (x, y)"
+      var x, y: FP2_BLS381
+      discard ECP2_BLS381_get(x.addr, y.addr, pointG2.unsafeAddr)
+      echo "(", $x, ", ", $y, ")"
+
+    `test _ id`()
+
+  block: # hashToBaseFP2
+    testHashToG2 1:
+      let
+        msg = "msg"
+        dst = "BLS_SIG_BLS12381G2-SHA256-SSWU-RO_POP_"
+
+      # Expected output
+      let point = (
+        # x
+        ["0x7896efdac56b0f6cbd8c78841676d63fc733b692628687bf25273aa8a107bd8cb53bbdb705b551e239dffe019abd4df",
+         "0xbd557eda8d16ab2cb2e71cca4d7b343985064daad04734e07da5cdda26610b59cdc0810a25276467d24b315bf7860e0"],
+        # y
+        ["0x1bdb6290cae9f30f263dd40f014b9f4406c3fbbc5fea47e2ebd45e42332553961eb53a15c09e5e090d7a7122dc6657",
+         "18370459c44e799af8ef31634a683e340e79c3a06f912594d287a443620933b47a2a3e5ce4470539eae50f6d49b8ebd6"]
+      )

--- a/blscurve/hash_to_curve.nim
+++ b/blscurve/hash_to_curve.nim
@@ -83,7 +83,7 @@ func hashToBaseFP2[T](
   # it REQUIRES allocation in a buffer
   # with an extra null-byte beyond the declared length.
   assert not msg.isNil
-  assert cast[ptr UncheckedArray[byte]](msg)[msgLen+1] == 0x00
+  assert cast[ptr UncheckedArray[byte]](msg)[msgLen] == 0x00, "Expected message terminated by nul-byte but found " & $cast[ptr UncheckedArray[byte]](msg)[msgLen] & " (decimal value)"
   hkdfExtract(ctx, mprime, domainSepTag, domainSepTagLen, msg, msgLen+1)
 
   info[0] = ord'H'

--- a/blscurve/hkdf.nim
+++ b/blscurve/hkdf.nim
@@ -1,0 +1,324 @@
+# Nim-BLSCurve
+# Copyright (c) 2018-Present Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+# TODO: Move into nimcrypto
+# TODO: for use in BLS hash_to_curve (specifically hash_to_base subroutine)
+#       hkdf requires separate HKDF-Extract and HKDF-Expand.
+# Merge with: https://github.com/status-im/nim-eth/blob/b7ebf8ed/eth/p2p/discoveryv5/hkdf.nim
+
+# HMAC-based Extract-and-Expand Key Derivation Function (HKDF)
+# https://tools.ietf.org/html/rfc5869
+#
+# Overview
+# ----------------------------------------------------------------------
+# HKDF follows the "extract-then-expand" paradigm, where the KDF
+# logically consists of two modules.  The first stage takes the input
+# keying material and "extracts" from it a fixed-length pseudorandom
+# key K.  The second stage "expands" the key K into several additional
+# pseudorandom keys (the output of the KDF).
+#
+#
+# 2.2.  Step 1: Extract
+# HKDF-Extract(salt, IKM) -> PRK
+#
+# Options:
+#   Hash     a hash function; HashLen denotes the length of the
+#             hash function output in octets
+#
+# Inputs:
+#   salt     optional salt value (a non-secret random value);
+#             if not provided, it is set to a string of HashLen zeros.
+#   IKM      input keying material
+#
+# Output:
+#   PRK      a pseudorandom key (of HashLen octets)
+#
+# The output PRK is calculated as follows:
+#
+# PRK = HMAC-Hash(salt, IKM)
+#
+#
+#
+# 2.3.  Step 2: Expand
+#
+# HKDF-Expand(PRK, info, L) -> OKM
+#
+# Options:
+#   Hash     a hash function; HashLen denotes the length of the
+#             hash function output in octets
+#
+# Inputs:
+#   PRK      a pseudorandom key of at least HashLen octets
+#             (usually, the output from the extract step)
+#   info     optional context and application specific information
+#             (can be a zero-length string)
+#   L        length of output keying material in octets
+#             (<= 255*HashLen)
+#
+# Output:
+#   OKM      output keying material (of L octets)
+#
+# The output OKM is calculated as follows:
+#
+# N = ceil(L/HashLen)
+# T = T(1) | T(2) | T(3) | ... | T(N)
+# OKM = first L octets of T
+#
+# where:
+# T(0) = empty string (zero length)
+# T(1) = HMAC-Hash(PRK, T(0) | info | 0x01)
+# T(2) = HMAC-Hash(PRK, T(1) | info | 0x02)
+# T(3) = HMAC-Hash(PRK, T(2) | info | 0x03)
+# ...
+#
+# (where the constant concatenated to the end of each T(n) is a
+# single octet.)
+
+import nimcrypto/hmac
+
+func hkdfExtract*[T](ctx: var HMAC[T],
+                     prk: var MDigest[T.bits],
+                     salt: ptr byte, saltLen: uint,
+                     ikm: ptr byte, ikmLen: uint
+                    ) =
+  ## "Extract" step of HKDF.
+  ## Extract a fixed size pseudom-random key
+  ## from an optional salt value
+  ## and a secret input keying material.
+  ##
+  ## Inputs:
+  ## - salt + saltLen: a buffer to an optional salt value (set to nil if unused)
+  ## - ikm + ikmLen: "input keying material", the secret value to hash.
+  ##
+  ## Output:
+  ## - prk: a pseudo random key of fixed size. The size is the same as the cryptographic hash chosen.
+  ##
+  ## Temporary:
+  ## - ctx: a HMAC["cryptographic-hash"] context, for example HMAC[sha256].
+  mixin init, update, finish
+  ctx.init(salt, saltLen)
+  ctx.update(ikm, ikmLen)
+  discard ctx.finish(prk.data)
+
+  # ctx.clear() - TODO: very expensive
+
+func hkdfExpand*[T](ctx: var HMAC[T],
+                    prk: MDigest[T.bits],
+                    info: ptr byte, infoLen: uint,
+                    output: ptr byte, outLen: uint
+                  ) =
+  ## "Expand" step of HKDF
+  ## Expand a fixed size pseudo random-key
+  ## into several pseudo-random keys
+  ##
+  ## Inputs:
+  ## - prk: a pseudo random key (PRK) of fixed size. The size is the same as the cryptographic hash chosen.
+  ## - info + infolen: optional context and application specific information (set to nil if unused)
+  ## - outLen: The target length of the output
+  ##
+  ## Output:
+  ## - output: OKM (output keying material). The PRK is expanded to match
+  ##           outLen, the result is tored in output.
+  ##
+  ## Temporary:
+  ## - ctx: a HMAC["cryptographic-hash"] context, for example HMAC[sha256].
+  mixin init, update, finish
+
+  const HashLen = T.bits div 8
+
+  static: doAssert T.bits >= 0
+  # assert outLen <= 255*HashLen
+
+  let N = outLen div HashLen
+  var t: MDigest[T.bits]
+  let oArray = cast[ptr UncheckedArray[byte]](output)
+
+  for i in 0 .. N:
+    ctx.init(prk.data)
+    # T(0) = empty string
+    if i != 0:
+      ctx.update(t.data)
+    ctx.update(info, infoLen)
+    ctx.update([uint8(i+1)])
+    discard ctx.finish(t.data)
+
+    let iStart = i * HashLen
+    let size = min(HashLen, int(outLen - iStart))
+    copyMem(oArray[iStart].addr, t.data.addr, size)
+
+  # ctx.clear() - TODO: very expensive
+
+# Test vectors
+# ----------------------------------------------------------------------
+# https://tools.ietf.org/html/rfc5869#appendix-A
+
+when isMainModule:
+  import stew/byteutils, nimcrypto/[sha, sha2]
+
+  proc hexToBytes(s: string): seq[byte] =
+    if s.len != 0: return hexToSeqByte(s)
+
+  template test(id, constants: untyped) =
+    proc `test _ id`() =
+      # We create a proc to avoid allocating too much globals.
+      constants
+
+      let
+        bikm = hexToBytes(IKM)
+        bsalt = hexToBytes(salt)
+        binfo = hexToBytes(info)
+        bprk = hexToBytes(PRK)
+        bokm = hexToBytes(OKM)
+
+      var output = newSeq[byte](L)
+      var ctx: HMAC[HashType]
+      var prk: MDigest[HashType.bits]
+
+      let salt = if bsalt.len == 0: nil
+                 else: bsalt[0].unsafeAddr
+      let ikm = if bikm.len == 0: nil
+                else: bikm[0].unsafeAddr
+      let info = if binfo.len == 0: nil
+                 else: binfo[0].unsafeAddr
+
+      hkdfExtract(ctx, prk, salt, bsalt.len.uint, ikm, bikm.len.uint)
+      hkdfExpand(ctx, prk, info, binfo.len.uint, output[0].addr, output.len.uint)
+
+      doAssert @(prk.data) == bprk, "\nComputed     0x" & toHex(prk.data) &
+                                    "\nbut expected " & PRK & '\n'
+      doAssert output == bokm, "\nComputed     0x" & toHex(output) &
+                               "\nbut expected " & OKM & '\n'
+      echo "HKDF Test ", astToStr(id), " - SUCCESS"
+
+    `test _ id`()
+
+  test 1: # Basic test case with SHA-256
+    type HashType = sha256
+    const
+      IKM  = "0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"
+      salt = "0x000102030405060708090a0b0c"
+      info = "0xf0f1f2f3f4f5f6f7f8f9"
+      L    = 42
+
+      PRK  = "0x077709362c2e32df0ddc3f0dc47bba63" &
+             "90b6c73bb50f9c3122ec844ad7c2b3e5"
+      OKM  = "0x3cb25f25faacd57a90434f64d0362f2a" &
+             "2d2d0a90cf1a5a4c5db02d56ecc4c5bf" &
+             "34007208d5b887185865"
+
+  test 2: # Test with SHA-256 and longer inputs/outputs
+    type HashType = sha256
+    const
+      IKM  =  "0x000102030405060708090a0b0c0d0e0f" &
+              "101112131415161718191a1b1c1d1e1f" &
+              "202122232425262728292a2b2c2d2e2f" &
+              "303132333435363738393a3b3c3d3e3f" &
+              "404142434445464748494a4b4c4d4e4f"
+      salt =  "0x606162636465666768696a6b6c6d6e6f" &
+              "707172737475767778797a7b7c7d7e7f" &
+              "808182838485868788898a8b8c8d8e8f" &
+              "909192939495969798999a9b9c9d9e9f" &
+              "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf"
+      info =  "0xb0b1b2b3b4b5b6b7b8b9babbbcbdbebf" &
+              "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf" &
+              "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf" &
+              "e0e1e2e3e4e5e6e7e8e9eaebecedeeef" &
+              "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+      L    = 82
+
+      PRK  =  "0x06a6b88c5853361a06104c9ceb35b45c" &
+              "ef760014904671014a193f40c15fc244"
+      OKM  =  "0xb11e398dc80327a1c8e7f78c596a4934" &
+              "4f012eda2d4efad8a050cc4c19afa97c" &
+              "59045a99cac7827271cb41c65e590e09" &
+              "da3275600c2f09b8367793a9aca3db71" &
+              "cc30c58179ec3e87c14c01d5c1f3434f" &
+              "1d87"
+
+  test 3: # Test with SHA-256 and zero-length salt/info
+    type HashType = sha256
+    const
+      IKM  = "0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"
+      salt = ""
+      info = ""
+      L    = 42
+
+      PRK  = "0x19ef24a32c717b167f33a91d6f648bdf" &
+             "96596776afdb6377ac434c1c293ccb04"
+      OKM  = "0x8da4e775a563c18f715f802a063c5a31" &
+             "b8a11f5c5ee1879ec3454e5f3c738d2d" &
+             "9d201395faa4b61a96c8"
+
+  test 4: # Basic test case with SHA-1
+    type HashType = sha1
+    const
+      IKM  = "0x0b0b0b0b0b0b0b0b0b0b0b"
+      salt = "0x000102030405060708090a0b0c"
+      info = "0xf0f1f2f3f4f5f6f7f8f9"
+      L    = 42
+
+      PRK  = "0x9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243"
+      OKM  = "0x085a01ea1b10f36933068b56efa5ad81" &
+             "a4f14b822f5b091568a9cdd4f155fda2" &
+             "c22e422478d305f3f896"
+
+  test 5: # Test with SHA-1 and longer inputs/outputs
+    type HashType = sha1
+    const
+      IKM  = "0x000102030405060708090a0b0c0d0e0f" &
+             "101112131415161718191a1b1c1d1e1f" &
+             "202122232425262728292a2b2c2d2e2f" &
+             "303132333435363738393a3b3c3d3e3f" &
+             "404142434445464748494a4b4c4d4e4f"
+      salt = "0x606162636465666768696a6b6c6d6e6f" &
+             "707172737475767778797a7b7c7d7e7f" &
+             "808182838485868788898a8b8c8d8e8f" &
+             "909192939495969798999a9b9c9d9e9f" &
+             "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf"
+      info = "0xb0b1b2b3b4b5b6b7b8b9babbbcbdbebf" &
+             "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf" &
+             "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf" &
+             "e0e1e2e3e4e5e6e7e8e9eaebecedeeef" &
+             "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+      L    = 82
+
+      PRK  = "0x8adae09a2a307059478d309b26c4115a224cfaf6"
+      OKM  = "0x0bd770a74d1160f7c9f12cd5912a06eb" &
+             "ff6adcae899d92191fe4305673ba2ffe" &
+             "8fa3f1a4e5ad79f3f334b3b202b2173c" &
+             "486ea37ce3d397ed034c7f9dfeb15c5e" &
+             "927336d0441f4c4300e2cff0d0900b52" &
+             "d3b4"
+
+  test 6: # Test with SHA-1 and zero-length salt/info
+    type HashType = sha1
+    const
+      IKM  = "0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"
+      salt = ""
+      info = ""
+      L    = 42
+
+      PRK  = "0xda8c8a73c7fa77288ec6f5e7c297786aa0d32d01"
+      OKM  = "0x0ac1af7002b3d761d1e55298da9d0506" &
+             "b9ae52057220a306e07b6b87e8df21d0" &
+             "ea00033de03984d34918"
+
+  test 7: # Test with SHA-1, salt not provided (defaults to HashLen zero octets),
+          # zero-length info
+    type HashType = sha1
+    const
+      IKM  = "0x0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c"
+      salt = ""
+      info = ""
+      L    = 42
+
+      PRK  = "0x2adccada18779e7c2077ad2eb19d3f3e731385dd"
+      OKM  = "0x2c91117204d745f3500d636a62f64f0a" &
+             "b3bae548aa53d423b0d1f27ebba6f5e5" &
+             "673a081d70cce7acfc48"

--- a/blscurve/hkdf.nim
+++ b/blscurve/hkdf.nim
@@ -139,7 +139,7 @@ func hkdfExpand*[T](ctx: var HMAC[T],
   var t: MDigest[T.bits]
   let oArray = cast[ptr UncheckedArray[byte]](output)
 
-  for i in 0 .. N:
+  for i in 0'u .. N:
     ctx.init(prk.data)
     # T(0) = empty string
     if i != 0:

--- a/blscurve/milagro.nim
+++ b/blscurve/milagro.nim
@@ -263,3 +263,6 @@ proc FP2_BLS381_equals*(x: ptr FP2_BLS381, y: ptr FP2_BLS381): cint {.
 proc FP12_BLS381_equals*(x: ptr FP12_BLS381, y: ptr FP12_BLS381): cint {.
      milagro_func.}
 proc FP12_BLS381_isunity*(x: ptr FP12_BLS381): cint {.milagro_func.}
+
+# Debug
+proc FP2_BLS381_output*(x: ptr FP2_BLS381) {.sideeffect, milagro_func.}

--- a/blscurve/milagro.nim
+++ b/blscurve/milagro.nim
@@ -248,13 +248,16 @@ proc FP2_BLS381_from_FPs*(w: ptr FP2_BLS381, x, y: FP_BLS381) {.milagro_func.}
 proc FP2_BLS381_copy*(w: ptr FP2_BLS381, x: ptr FP2_BLS381) {.milagro_func.}
 proc FP2_BLS381_reduce*(w: ptr FP2_BLS381) {.milagro_func.}
 proc FP2_BLS381_one*(w: ptr FP2_BLS381) {.milagro_func.}
-proc FP2_BLS381_sqrt*(w: ptr FP2_BLS381, u: ptr FP2_BLS381): cint {.
-     milagro_func.}
 proc FP2_BLS381_add*(w: ptr FP2_BLS381, x: ptr FP2_BLS381, y: ptr FP2_BLS381) {.
+     milagro_func.}
+proc FP2_BLS381_sub*(w: ptr FP2_BLS381, x: ptr FP2_BLS381, y: ptr FP2_BLS381) {.
      milagro_func.}
 proc FP2_BLS381_mul*(x: ptr FP2_BLS381, y: ptr FP2_BLS381, z: ptr FP2_BLS381) {.
      milagro_func.}
-proc FP2_BLS381_sqr*(w: ptr FP2_BLS381, x: ptr FP2_BLS381) {. milagro_func.}
+proc FP2_BLS381_div2*(x: ptr FP2_BLS381, y: ptr FP2_BLS381){.milagro_func.}
+proc FP2_BLS381_sqr*(w: ptr FP2_BLS381, x: ptr FP2_BLS381){.milagro_func.}
+proc FP2_BLS381_sqrt*(x: ptr FP2_BLS381, y: ptr FP2_BLS381): cint {.milagro_func.}
+proc FP2_BLS381_pow*(x: ptr FP2_BLS381, y: ptr FP2_BLS381, b: BIG_384){.milagro_func.}
 proc FP2_BLS381_equals*(x: ptr FP2_BLS381, y: ptr FP2_BLS381): cint {.
      milagro_func.}
 proc FP12_BLS381_equals*(x: ptr FP12_BLS381, y: ptr FP12_BLS381): cint {.

--- a/blscurve/milagro.nim
+++ b/blscurve/milagro.nim
@@ -240,6 +240,7 @@ proc FP_BLS381_equals*(x: ptr FP_BLS381, y: ptr FP_BLS381): cint {.
 
 proc FP2_BLS381_inv*(x: ptr FP2_BLS381, y: ptr FP2_BLS381) {.milagro_func.}
 proc FP2_BLS381_iszilch*(x: ptr FP2_BLS381): cint {.milagro_func.}
+proc FP2_BLS381_cmove*(x, y: ptr FP2_BLS381, s: cint) {.milagro_func.}
 proc FP2_BLS381_norm*(x: ptr FP2_BLS381) {.milagro_func.}
 proc FP2_BLS381_neg*(r: ptr FP2_BLS381, a: ptr FP2_BLS381) {.milagro_func.}
 proc FP2_BLS381_from_BIGs*(w: ptr FP2_BLS381, x, y: BIG_384) {.milagro_func.}

--- a/blscurve/milagro.nim
+++ b/blscurve/milagro.nim
@@ -238,6 +238,7 @@ proc FP_BLS381_neg*(r: ptr FP_BLS381, a: ptr FP_BLS381) {.milagro_func.}
 proc FP_BLS381_equals*(x: ptr FP_BLS381, y: ptr FP_BLS381): cint {.
      milagro_func.}
 
+proc FP2_BLS381_inv*(x: ptr FP2_BLS381, y: ptr FP2_BLS381) {.milagro_func.}
 proc FP2_BLS381_iszilch*(x: ptr FP2_BLS381): cint {.milagro_func.}
 proc FP2_BLS381_norm*(x: ptr FP2_BLS381) {.milagro_func.}
 proc FP2_BLS381_neg*(r: ptr FP2_BLS381, a: ptr FP2_BLS381) {.milagro_func.}
@@ -249,6 +250,8 @@ proc FP2_BLS381_one*(w: ptr FP2_BLS381) {.milagro_func.}
 proc FP2_BLS381_sqrt*(w: ptr FP2_BLS381, u: ptr FP2_BLS381): cint {.
      milagro_func.}
 proc FP2_BLS381_add*(w: ptr FP2_BLS381, x: ptr FP2_BLS381, y: ptr FP2_BLS381) {.
+     milagro_func.}
+proc FP2_BLS381_mul*(x: ptr FP2_BLS381, y: ptr FP2_BLS381, z: ptr FP2_BLS381) {.
      milagro_func.}
 proc FP2_BLS381_sqr*(w: ptr FP2_BLS381, x: ptr FP2_BLS381) {. milagro_func.}
 proc FP2_BLS381_equals*(x: ptr FP2_BLS381, y: ptr FP2_BLS381): cint {.

--- a/blscurve/milagro.nim
+++ b/blscurve/milagro.nim
@@ -214,6 +214,12 @@ proc ECP2_BLS381_neg*(p: ptr ECP2_BLS381) {.milagro_func.}
 proc ECP2_BLS381_mul*(p: ptr ECP2_BLS381, e: BIG_384) {.milagro_func.}
 proc ECP2_BLS381_add*(p: ptr ECP2_BLS381, q: ptr ECP2_BLS381): cint {.
      milagro_func.}
+proc ECP2_BLS381_sub*(p: ptr ECP2_BLS381, q: ptr ECP2_BLS381): cint {.
+     milagro_func.}
+proc ECP2_BLS381_dbl*(p: ptr ECP2_BLS381): cint {.
+     milagro_func.}
+proc ECP2_BLS381_frob*(p: ptr ECP2_BLS381, frobConst: ptr FP2_BLS381): cint {.
+     milagro_func.}
 proc ECP2_BLS381_generator*(g: ptr ECP2_BLS381) {.milagro_func.}
 proc ECP2_BLS381_get*(x: ptr FP2_BLS381, y: ptr FP2_BLS381,
                       p: ptr ECP2_BLS381): cint {.milagro_func.}
@@ -226,7 +232,6 @@ proc ECP2_BLS381_set*(p: ptr ECP2_BLS381, x: ptr FP2_BLS381,
                       y: ptr FP2_BLS381): cint {.milagro_func.}
 proc ECP2_BLS381_rhs*(r: ptr FP2_BLS381, x: ptr FP2_BLS381) {.
      milagro_func.}
-proc ECP2_BLS381_dbl*(p: ptr ECP2_BLS381): cint {.milagro_func.}
 
 proc FP_BLS381_redc*(x: BIG_384, y: ptr FP_BLS381) {.milagro_func.}
 proc FP_BLS381_nres*(y: ptr FP_BLS381, x: BIG_384) {.milagro_func.}

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -6,4 +6,7 @@
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
-import test_scheme, test_vectors
+import
+  test_scheme,  # Before IETF standardization
+  test_vectors, # Eth2 v0.9.x API
+  ietf_hash_to_curve

--- a/tests/ietf_hash_to_curve.nim
+++ b/tests/ietf_hash_to_curve.nim
@@ -82,23 +82,22 @@ suite "IETF Hash-to-Curve G2 BLS12-381":
         )
       )
 
-  # TODO: empty strings hashing
-  # test "Py-ECC #3 ''":
-  #   testHashToG2:
-  #     let msg = ""
-  #
-  #     let ecp = toECP2(
-  #       x = hexToFP2(
-  #         # x = x' + iy'
-  #         x = "0x0c38e18c9ca92ad387cbfa0e9bd62e53e4f938006097a092d5e9f2c6f3963d78969e7631bf8d6a8a9aad36bc82d763c1",
-  #         y = "0x023ebc431b239ee7606aad7cd4eee60bb70df3e5072ede86946ffaddb0584e1fcfcee9484869f41e09ab4d64b9e4a72a"
-  #       ),
-  #       y = hexToFP2(
-  #         # y = x'' + iy''
-  #         x = "0x0735ae5ca4a2320d820e15501ee79c42ff58a6f40e8549eada554e07c94b34b6634b6034f8735a7e4ac01db81b00f58e",
-  #         y = "0x1687b6a2fb9e542426d508d4a58846c0e3496ede2e12f57f3358110874ba0011e2107e0742eeb6707682d5ddf319b6f6"
-  #       )
-  #     )
+  test "Py-ECC #3 ''":
+    testHashToG2:
+      let msg = ""
+
+      let ecp = toECP2(
+        x = hexToFP2(
+          # x = x' + iy'
+          x = "0x0c38e18c9ca92ad387cbfa0e9bd62e53e4f938006097a092d5e9f2c6f3963d78969e7631bf8d6a8a9aad36bc82d763c1",
+          y = "0x023ebc431b239ee7606aad7cd4eee60bb70df3e5072ede86946ffaddb0584e1fcfcee9484869f41e09ab4d64b9e4a72a"
+        ),
+        y = hexToFP2(
+          # y = x'' + iy''
+          x = "0x0735ae5ca4a2320d820e15501ee79c42ff58a6f40e8549eada554e07c94b34b6634b6034f8735a7e4ac01db81b00f58e",
+          y = "0x1687b6a2fb9e542426d508d4a58846c0e3496ede2e12f57f3358110874ba0011e2107e0742eeb6707682d5ddf319b6f6"
+        )
+      )
 
   test "Py-ECC #4 b'abcdefghijklmnopqrstuvwxyz'":
     testHashToG2:

--- a/tests/ietf_hash_to_curve.nim
+++ b/tests/ietf_hash_to_curve.nim
@@ -1,0 +1,169 @@
+# Nim-BLSCurve
+# Copyright (c) 2018-Present Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  # Standard library
+  unittest, strutils,
+  # Internals
+  ../blscurve/[common, milagro, hash_to_curve]
+
+# Vectors for Hash to G2 curve of BLS12-381
+# According to the IETF standard draft https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-05
+
+func hexToFP2(x, y: string): FP2_BLS381 =
+  ## Convert a complex tuple x + iy to FP2
+  # TODO: the result does not seem to need zero-initialization
+  var xBig, yBig: BIG_384
+
+  discard xBig.fromHex(x)
+  discard yBig.fromHex(y)
+
+  result.fromBigs(xBig, yBig)
+
+proc toECP2(x, y: FP2_BLS381): ECP2_BLS381 =
+  ## Create a point (x, y) on the G2 curve
+  let onCurve = bool ECP2_BLS381_set(addr result, unsafeAddr x, unsafeAddr y)
+  doAssert onCurve, "The coordinates (x, y) are not on the G2 curve"
+
+template testHashToG2(constants: untyped) =
+  ## Hash-to-curve "msg" and "dst" (domain separation tag)
+  ## and compare the computed point
+  ## with the expected point "ecp"
+  proc testScenario() =
+    # We create a proc to avoid allocating too many global variables
+    constants
+
+    let computedG2 = hashToG2(msg, dst)
+
+    check: computedG2 == ecp
+
+  testScenario()
+
+suite "IETF Hash-to-Curve G2 BLS12-381":
+  let dst = "BLS_SIG_BLS12381G2-SHA256-SSWU-RO_POP_"
+
+  test "Py-ECC #1 b'msg'":
+    testHashToG2:
+      let msg = "msg"
+
+      let ecp = toECP2(
+        x = hexToFP2(
+          # x = x' + iy'
+          x = "0x07896efdac56b0f6cbd8c78841676d63fc733b692628687bf25273aa8a107bd8cb53bbdb705b551e239dffe019abd4df",
+          y = "0x0bd557eda8d16ab2cb2e71cca4d7b343985064daad04734e07da5cdda26610b59cdc0810a25276467d24b315bf7860e0"
+        ),
+        y = hexToFP2(
+          # y = x'' + iy''
+          x = "0x001bdb6290cae9f30f263dd40f014b9f4406c3fbbc5fea47e2ebd45e42332553961eb53a15c09e5e090d7a7122dc6657",
+          y = "0x18370459c44e799af8ef31634a683e340e79c3a06f912594d287a443620933b47a2a3e5ce4470539eae50f6d49b8ebd6"
+        )
+      )
+
+  test "Py-ECC #2 b'01234567890123456789012345678901'":
+    testHashToG2:
+      let msg = "01234567890123456789012345678901"
+
+      let ecp = toECP2(
+        x = hexToFP2(
+          # x = x' + iy'
+          x = "0x16b7456df1dfa411b8be80c503864b0795b0b9a7674c05c00e7bdee5a75cbdeec633e16a104406ea626ea6845f5d19b5",
+          y = "0x12ae54eeb3b4dc113d7e80302e51456224087955910479929bf912d89177aa050376960002a96fc6541ac041957f4b93"
+        ),
+        y = hexToFP2(
+          # y = x'' + iy''
+          x = "0x1632fe9d91a984f30a7d9b3bab6583974a2ca55933d96cba85f39ddd61ea0129274f75ad7de29473adf3db676dcdb6a3",
+          y = "0x08d5d3b670fca3661122b0ca5929e48f293a5a5c1261050c46b6a08eac3f7d1f5075e2139a63f98e717ecc7c2e00d042"
+        )
+      )
+
+  # TODO: empty strings hashing
+  # test "Py-ECC #3 ''":
+  #   testHashToG2:
+  #     let msg = ""
+  #
+  #     let ecp = toECP2(
+  #       x = hexToFP2(
+  #         # x = x' + iy'
+  #         x = "0x0c38e18c9ca92ad387cbfa0e9bd62e53e4f938006097a092d5e9f2c6f3963d78969e7631bf8d6a8a9aad36bc82d763c1",
+  #         y = "0x023ebc431b239ee7606aad7cd4eee60bb70df3e5072ede86946ffaddb0584e1fcfcee9484869f41e09ab4d64b9e4a72a"
+  #       ),
+  #       y = hexToFP2(
+  #         # y = x'' + iy''
+  #         x = "0x0735ae5ca4a2320d820e15501ee79c42ff58a6f40e8549eada554e07c94b34b6634b6034f8735a7e4ac01db81b00f58e",
+  #         y = "0x1687b6a2fb9e542426d508d4a58846c0e3496ede2e12f57f3358110874ba0011e2107e0742eeb6707682d5ddf319b6f6"
+  #       )
+  #     )
+
+  test "Py-ECC #4 b'abcdefghijklmnopqrstuvwxyz'":
+    testHashToG2:
+      let msg = "abcdefghijklmnopqrstuvwxyz"
+
+      let ecp = toECP2(
+        x = hexToFP2(
+          # x = x' + iy'
+          x = "0x0db85d0c792c586c6efb4126e98a8a8788d28187a6432cbdd57444a8c937ce20e0fc0774477150d31bfff83a050b530e",
+          y = "0x13505f5cbb1503c7b1206edd31364a467f5159d741cffe8f443f2282b4adfcf5f1450bd2fe6127991ff60955b3b40015"
+        ),
+        y = hexToFP2(
+          # y = x'' + iy''
+          x = "0x1738e4903e5618fcba965861c73d7c7a7544fabc9762ccdf9842dbba30566ce33047c3ff714ce8a10323bcac0ee88479",
+          y = "0x0d0df337706a8b4c367ea189d9e213f47455399ddf734358695e84ad09630a724082ad22dda74e6cd41378dbb89b0ebd"
+        )
+      )
+
+  test "Py-ECC #5 b'\\xFF' * 100":
+    testHashToG2:
+      let msg = "\xFF".repeat(100)
+
+      let ecp = toECP2(
+        x = hexToFP2(
+          # x = x' + iy'
+          x = "0x0a2b9bb7afda6e1c3cb2340aa679ce00469a14c651becd30fa231c83ab82d1b92db074058c3673daaaa2a113f0c3ea56",
+          y = "0x0e7fcdf25cf4465f58de593bf6445ec1cd164de346a27ed46314dcbb35a830650f5bb4d8049878d9a84a34013fa4fb11"
+        ),
+        y = hexToFP2(
+          # y = x'' + iy''
+          x = "0x14f909c9fb9fb14c0e7455ed5306edaad40e7c57cdd719f59730db6ae64161db1f1a8159db4d97700fba7547920fe1a2",
+          y = "0x1702a797d33e0c7b3fac012da0ef1960e0f4551f23ffee3e12dc36ac4acdd6d78bee97bad76689b8e70dac80449a626c"
+        )
+      )
+
+  test "Py-ECC #6 b'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'":
+    testHashToG2:
+      let msg = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+      let ecp = toECP2(
+        x = hexToFP2(
+          # x = x' + iy'
+          x = "0x07e2b8b61562339640addfda3202f5d657aa77c143bf5bceda818525ba6f984eba2648528928d6c9680f752dd88d91e3",
+          y = "0x1663cd7231bd9708bebe0be61baecf2b89ebaa658150696f5be2dbe0e092ec698c931e8795ac6319f1c5fdda5d14136a"
+        ),
+        y = hexToFP2(
+          # y = x'' + iy''
+          x = "0x033d40a6eb88c11c6018fcc00489bc4b9dd700c20d1bab21ad463c5ee63ce671d199020ba743828d450da050f0385680",
+          y = "0x10336a533d1e3564da20bffe87ebc82121cfbfad2e36ecb950c5e12d8552bf932f5f5e846a50e9706b21b0db6585a777"
+        )
+      )
+
+  test "Py-ECC #7 b'e46b320165eec91e6344fa10340d5b3208304d6cad29d0d5aed18466d1d9d80e'":
+    testHashToG2:
+      let msg = "e46b320165eec91e6344fa10340d5b3208304d6cad29d0d5aed18466d1d9d80e"
+
+      let ecp = toECP2(
+        x = hexToFP2(
+          # x = x' + iy'
+          x = "0x119a71e0d20489cf8c5f82c51e879e7b344e53307b53be650df7f3f04907b75b71fdafe26e8d4e14e603440b09efe6f3",
+          y = "0x0e4ea193377da29537e8fe6f6f631adff10afaef2ea1eb2107d30d97358c1a19975e0a8bb62650ff90447cf5b3719c1d"
+        ),
+        y = hexToFP2(
+          # y = x'' + iy''
+          x = "0x1142f2e077cc4230ee3cf07565ee626141ea9b86a79a0422d7f0e84c281ca09c5bbbe95f21e51285618c81d6dfda943d",
+          y = "0x015e4da056552343eb519b3087962521d112c7e307d731373e8f1c72415306ccbc3c14fc6d68d61d2feeda3ea2e7729f"
+        )
+      )

--- a/tests/test_scheme.nim
+++ b/tests/test_scheme.nim
@@ -20,7 +20,7 @@ const messages = [
 const
   domain = 0'u64
 
-suite "BLS381-12 test suite (public interface)":
+suite "[Before IETF standard] BLS381-12 test suite (public interface)":
 
   test "Simple successful sign/verification tests":
     var kp = KeyPair.random()

--- a/tests/test_vectors.nim
+++ b/tests/test_vectors.nim
@@ -200,7 +200,7 @@ proc readCase07Vector(file: File, vector: var Case07Vector): bool =
   vector.apublickey = align(fromHex(m[3]), MODBYTES_384)
   result = true
 
-suite "Ethereum2 specification BLS381-12 test vectors suite":
+suite "[v0.9.x] Ethereum2 specification BLS381-12 test vectors suite":
 
   test "case01_message_hash_G2_uncompressed":
     var f = openVectorFile("case01_message_hash_G2_uncompressed.dat")


### PR DESCRIPTION
This a WIP implementing the new hashToG2 primitive according to the IETF draft spec.

- IETF Standard Draft: https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-04
  - Formatted HTML version: https://cfrg.github.io/draft-irtf-cfrg-hash-to-curve/draft-irtf-cfrg-hash-to-curve.html
- IETF Implementation: https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve
  - The following can be used as a test vector generator:
    https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve/blob/6cf7fa97/poc/suite_bls12381g2.sage
- Ethereum Foundation implementation: https://github.com/ethereum/py_ecc
  - Specific PR: https://github.com/ethereum/py_ecc/pull/83/files

Currently, the implementation is incorrect and need heavy debugging. Unfortunately I'm lacking some test vectors. Py-ECC code doesn't follow the spec for the implementations but reference papers. The code from MCL is at the moment incomplete: https://github.com/herumi/mcl/commit/8ec855f162f97f64b1bab9838068b1425ad0d39a, there is no vectors.
Alternative implementations are also missing vectors: https://github.com/kwantam/bls12-381_hash/tree/master/src / https://github.com/kwantam/bls_sigs_ref / https://github.com/algorand/bls_sigs_ref

### Dropping Milagro

If we want to drop Milagro, this is a good time.

#### Alternative 1 - Herumi's MCL / BLS

This would be a battery included library, supported by the EF.
Note that in our context (ARM devices within a MIT/Apache codebase) the major speed bonuses probably won't apply:
- Cannot use GMP
- Cannot use the JIT Assembler Xbyak

The main draw is that we only have to wrap.

#### Alternative 2 - Using Riad S. Wahby C implementation

Riad is the one of the co-lead for the IETF draft specification and has a constant-time C implementation at https://github.com/kwantam/bls12-381_hash (Apache v2 License).

Edit: I didn't see that it's using GMP :/

### Switching cost

Using Riad's code will require reimplementing signature aggregation and proof-of-possession on top of their primitives: https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-00#section-2.7

I think this is also true for Milagro, unless the aggregation/PoP scheme is the same as 0.9.x

### Other blockchains

With @arnetheduck [nbindgen](https://github.com/arnetheduck/nbindgen) we can reuse Zcash pairing library: https://github.com/zkcrypto/pairing. (Apache v2 + MIT License)

However the code by Zcash (https://github.com/zkcrypto/pairing) implements neither hash_to_curve nor aggregation/Proof-of-Possessions at the moment and such development doesn't seem to have started.

Alternatively there is a Go/C/C++ port by the University of Berkeley at https://github.com/ucbrise/jedi-pairing (BSD-3-Clause license) but same problem.

The code by Dfinity is using MCL: https://github.com/dfinity-side-projects/random-beacon

The code by Chia is using outdated hashToG2 and aggregates/PoP like us: https://github.com/Chia-Network/bls-signatures

### Not dropping Milagro

Not dropping Milagro means fixing this PR, which may be quite involved.

1. For example, assuming FP2 an extension field of characteristic P (prime) of order 2:
- FP2 elements are complex big integers in the form `A + iB (mod P)`,
- the spec requires `(A + iB) div (C + iD) (mod P)` in multiple places
- Milagro doesn't provide a modular complex bigint division, so right now it's implemented by multiplying by the multiplicative inverse (mod P), which may or may not be OK.
- If that is an issue that might require implementing complex bigint division.

2. The draft implementation accompanying the spec requires Python 2 to run: https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve/issues/199. It would however help to produce intermediate test-vectors to narrow-down what components are creating errors.

3. Py-ECC can be edited to output intermediate results: https://github.com/mratsim/py_ecc/commit/d09c42c73c73f0a24d0498568eb061b1eac16ab0, this requires some playing around the G2 points  representation: Jacobian (x, y, z) coordinates or Affine (x, y) / x + iy coordinates. We can output to both format but the input will require some extra code as there is no builtin Milagro functions.

4. At the moment it is unknown if our aggregation scheme is conforming to the new IETF spec.

------------
Thoughts?