### PR TITLE
[Don't Merge] Debug Milagro C vs Milagro Rust Bigint -> Field element conversion

### DIFF
--- a/blscurve/csources/64/fp_BLS381.c
+++ b/blscurve/csources/64/fp_BLS381.c
@@ -175,8 +175,15 @@ void FP_BLS381_nres(FP_BLS381 *y,BIG_384_58 x)
     DBIG_384_58 d;
     BIG_384_58 r;
     BIG_384_58_rcopy(r,R2modp_BLS381);
+    printf("r: ");
+    BIG_384_58_output(r);
+    printf("\nd: ");
     BIG_384_58_mul(d,x,r);
+    BIG_384_58_doutput(d);
+    printf("\nmod d: ");
     FP_BLS381_mod(y->g,d);
+    BIG_384_58_output(y->g);
+    printf("\n");
     y->XES=2;
 }
 

--- a/blscurve/csources/64/fp_BLS381.c
+++ b/blscurve/csources/64/fp_BLS381.c
@@ -204,7 +204,16 @@ void FP_BLS381_mod(BIG_384_58 a,DBIG_384_58 d)
 {
     BIG_384_58 mdls;
     BIG_384_58_rcopy(mdls,Modulus_BLS381);
+    printf("\nstart mod, result: ");
+    BIG_384_58_output(a);
+    printf("\nstart mod, d: ");
+    BIG_384_58_doutput(d);
+    printf("\nstart mod, modulus: ");
+    BIG_384_58_output(mdls);
     BIG_384_58_monty(a,mdls,MConst_BLS381,d);
+    printf("\nend mod, monty: ");
+    BIG_384_58_output(a);
+    printf("\n");
 }
 
 #endif

--- a/blscurve/csources/64/fp_BLS381.c
+++ b/blscurve/csources/64/fp_BLS381.c
@@ -175,15 +175,15 @@ void FP_BLS381_nres(FP_BLS381 *y,BIG_384_58 x)
     DBIG_384_58 d;
     BIG_384_58 r;
     BIG_384_58_rcopy(r,R2modp_BLS381);
-    printf("r: ");
-    BIG_384_58_output(r);
-    printf("\nd: ");
+    // printf("r: ");
+    // BIG_384_58_output(r);
+    // printf("\nd: ");
     BIG_384_58_mul(d,x,r);
-    BIG_384_58_doutput(d);
-    printf("\nmod d: ");
+    // BIG_384_58_doutput(d);
+    // printf("\nmod d: ");
     FP_BLS381_mod(y->g,d);
-    BIG_384_58_output(y->g);
-    printf("\n");
+    // BIG_384_58_output(y->g);
+    // printf("\n");
     y->XES=2;
 }
 
@@ -204,16 +204,16 @@ void FP_BLS381_mod(BIG_384_58 a,DBIG_384_58 d)
 {
     BIG_384_58 mdls;
     BIG_384_58_rcopy(mdls,Modulus_BLS381);
-    printf("\nstart mod, result: ");
-    BIG_384_58_output(a);
-    printf("\nstart mod, d: ");
-    BIG_384_58_doutput(d);
-    printf("\nstart mod, modulus: ");
-    BIG_384_58_output(mdls);
+    // printf("\nstart mod, result: ");
+    // BIG_384_58_output(a);
+    // printf("\nstart mod, d: ");
+    // BIG_384_58_doutput(d);
+    // printf("\nstart mod, modulus: ");
+    // BIG_384_58_output(mdls);
     BIG_384_58_monty(a,mdls,MConst_BLS381,d);
-    printf("\nend mod, monty: ");
-    BIG_384_58_output(a);
-    printf("\n");
+    // printf("\nend mod, monty: ");
+    // BIG_384_58_output(a);
+    // printf("\n");
 }
 
 #endif


### PR DESCRIPTION
This adds debug output to Milagro FP conversion.

Script (assumes being run from `build/` folder)

```
import ../blscurve/[common, milagro]

var a0: BIG_384

discard a0.fromHex("004AD233C619209060E40059B81E4C1F92796B05AA1BC6358D65E53DC0D657DFBC713D4030B0B6D9234A6634FD1944E7")
echo "a0 (big): ", a0

let a0_fp = nres(a0)
echo "a0 (FP): ", a0_fp
```

Output

```
a0 (big): 004ad233c619209060e40059b81e4c1f92796b05aa1bc6358d65e53dc0d657dfbc713d4030b0b6d9234a6634fd1944e7
r: 19ea66a2b13c5b3fb47e72f38a6de8fb36639944712d8c5c3976e2d09b54e6e2cd249131918b764fa20639a1d5bef7ae
d: 7930930f8f9d0f7bfa6bad68e1ef9878495afa7f15372e6899ceb32e8251bbea96468e3bc57e89ace9dd8273565d9e00c4306b4f881788c607795679aa8eb1f4380297416ab005058a7ce18750aacfd08b6b6a8fc9e0d4fbe3b93bf19b602
mod d: 0a8a4e02721e4947b373f6f6c879a638acd4d47a24919f37a023cfe5149ab6f0547e1b4c42c94ed91b3b2e1c69a05d32
a0 (FP): 004ad233c619209060e40059b81e4c1f92796b05aa1bc6358d65e53dc0d657dfbc713d4030b0b6d9234a6634fd1944e7
```