### PR TITLE
Fix secretKey bigger than curve order and stack smashing in ECP mul

### DIFF
--- a/blscurve/bls_signature_scheme.nim
+++ b/blscurve/bls_signature_scheme.nim
@@ -526,19 +526,14 @@ func keyGen*(ikm: openarray[byte], publicKey: var PublicKey, secretKey: var Secr
 
   #  3. x = OS2IP(OKM) mod r
   #  5. SK = x
-  debugecho "keyGen:"
-  if not secretKey.intVal.fromBytes(okm):
+  var dseckey: DBIG_384
+  if not dseckey.fromBytes(okm):
     return false
-  {.noSideEffect.}:
-    debugecho "  CURVE_Order: ", CURVE_Order.toHex()
-    BIG_384_mod(secretKey.intVal, CURVE_Order)
 
-  debugecho "  seckey (mod): ", secretKey.toHex()
+  {.noSideEffect.}:
+    BIG_384_dmod(secretKey.intVal, dseckey, CURVE_Order)
 
   #  4. xP = x * P
   #  6. PK = point_to_pubkey(xP)
   publicKey = privToPub(secretKey)
-
-  debugecho "  seckey (exit): ", secretKey.toHex()
-
   return true

--- a/blscurve/bls_signature_scheme.nim
+++ b/blscurve/bls_signature_scheme.nim
@@ -513,11 +513,7 @@ func keyGen*(ikm: openarray[byte], publicKey: var PublicKey, secretKey: var Secr
   var prk: MDigest[sha256.bits]
 
   # 1. PRK = HKDF-Extract("BLS-SIG-KEYGEN-SALT-", IKM)
-  ctx.hkdfExtract(
-    prk,
-    cast[ptr byte](salt[0].unsafeAddr), salt.len.uint,
-    ikm[0].unsafeAddr, ikm.len.uint
-  )
+  ctx.hkdfExtract(prk, salt, ikm)
 
   # curve order r = 52435875175126190479447740508185965837690552500527637822603658699938581184513
   # const L = ceil((1.5 * ceil(log2(r))) / 8) = 48
@@ -526,17 +522,23 @@ func keyGen*(ikm: openarray[byte], publicKey: var PublicKey, secretKey: var Secr
   #  2. OKM = HKDF-Expand(PRK, "", L)
   const L = 48
   var okm: array[L, byte]
-  ctx.hkdfExpand(prk, nil, 0, okm[0].addr, L)
+  ctx.hkdfExpand(prk, "", okm)
 
   #  3. x = OS2IP(OKM) mod r
   #  5. SK = x
+  debugecho "keyGen:"
   if not secretKey.intVal.fromBytes(okm):
     return false
   {.noSideEffect.}:
+    debugecho "  CURVE_Order: ", CURVE_Order.toHex()
     BIG_384_mod(secretKey.intVal, CURVE_Order)
+
+  debugecho "  seckey (mod): ", secretKey.toHex()
 
   #  4. xP = x * P
   #  6. PK = point_to_pubkey(xP)
   publicKey = privToPub(secretKey)
+
+  debugecho "  seckey (exit): ", secretKey.toHex()
 
   return true


### PR DESCRIPTION
This PR changes 2 things:

1. it uses a DBIG_384 (double BIG_384) in to hold the raw bytes coming from HKDF-expand.
  Some of the raw outputs require more than 381-bit
  With a BIG the fromBytes procedure doesn't fail, the resulting BIG can be printed but calling norm or mod on it gives incorrect result and this creates an invalid secret key that causes stack smashing issues: https://github.com/status-im/nim-blscurve/issues/40#issuecomment-597573079, https://github.com/status-im/nim-beacon-chain/pull/780

2. In the process of debugging, I changed HKDF to use openarray thinking that the rootcause was hidden in some raw pointers