### PR TITLE
Switch default to BLS draft v7, used by v0.12.x

### DIFF
--- a/blscurve/bls_signature_scheme.nim
+++ b/blscurve/bls_signature_scheme.nim
@@ -30,7 +30,7 @@ import
   # internal
   ./milagro, ./common, ./hkdf
 
-const BLS_ETH2_SPEC* {.strdefine.} = "v0.11.x"
+const BLS_ETH2_SPEC* {.strdefine.} = "v0.12.x"
 when BLS_ETH2_SPEC == "v0.11.x":
   import ./draft_v5/hash_to_curve_draft_v5
 else:


### PR DESCRIPTION
Ready to commit. But 32-bit Windows Azure shows:
```
========================== Starting Command Output ===========================
"C:\Program Files\Git\bin\bash.exe" --noprofile --norc /d/a/_temp/4646d1d4-3400-4b89-a5ae-90c117ab9ce9.sh
PATH=/mingw64/bin:/usr/bin:/c/Users/VssAdministrator/bin:/c/agents/2.170.1/externals/git/cmd:/c/Program Files/Mercurial:/c/Program Files/MongoDB/Server/4.2/bin:/c/ProgramData/kind:/c/Program Files/PostgreSQL/12/bin:/c/vcpkg:/c/cf-cli:/c/Program Files (x86)/NSIS:/c/Program Files/Mercurial:/c/hostedtoolcache/windows/stack/2.3.1/x64:/c/ProgramData/chocolatey/lib/ghc.8.10.1/tools/ghc-8.10.1/bin:/c/Program Files/dotnet:/c/mysql-5.7.21-winx64/bin:/c/Program Files/Java/zulu-8-azure-jdk_8.40.0.25-8.0.222-win_x64/bin:/c/SeleniumWebDrivers/GeckoDriver:/c/Program Files (x86)/sbt/bin:/c/Rust/.cargo/bin:/c/hostedtoolcache/windows/go/1.14.4/x64/bin:/c/Program Files (x86)/GitHub CLI:/bin:/c/hostedtoolcache/windows/Python/3.7.7/x64/Scripts:/c/hostedtoolcache/windows/Python/3.7.7/x64:/c/hostedtoolcache/windows/Ruby/2.5.8/x64/bin:/c/npm/prefix:/c/Program Files (x86)/Microsoft SDKs/Azure/CLI2/wbin:/c/windows/system32:/c/windows:/c/windows/System32/Wbem:/c/windows/System32/WindowsPowerShell/v1.0:/c/windows/System32/OpenSSH:/c/ProgramData/Chocolatey/bin:/c/Program Files/Docker:/c/Program Files/PowerShell/7:/c/Program Files/dotnet:/c/Program Files/Microsoft SQL Server/130/Tools/Binn:/c/Program Files/Microsoft SQL Server/Client SDK/ODBC/170/Tools/Binn:/c/Program Files (x86)/Microsoft SQL Server/110/DTS/Binn:/c/Program Files (x86)/Microsoft SQL Server/120/DTS/Binn:/c/Program Files (x86)/Microsoft SQL Server/130/DTS/Binn:/c/Program Files (x86)/Microsoft SQL Server/140/DTS/Binn:/c/Program Files (x86)/Microsoft SQL Server/150/DTS/Binn:/c/Program Files (x86)/Windows Kits/10/Windows Performance Toolkit:/c/Program Files/Microsoft Service Fabric/bin/Fabric/Fabric.Code:/c/Program Files/Microsoft SDKs/Service Fabric/Tools/ServiceFabricLocalClusterManager:/c/Program Files/nodejs:/c/Program Files/OpenSSL/bin:/c/Strawberry/c/bin:/c/Strawberry/perl/site/bin:/c/Strawberry/perl/bin:/cmd:/mingw64/bin:/usr/bin:/c/tools/php:/c/Program Files (x86)/sbt/bin:/c/Program Files (x86)/Subversion/bin:/c/SeleniumWebDrivers/ChromeDriver:/c/SeleniumWebDrivers/EdgeDriver:/c/ProgramData/chocolatey/lib/maven/apache-maven-3.6.3/bin:/c/Program Files/CMake/bin:/c/Program Files/Amazon/AWSCLIV2:/c/Program Files/Amazon/AWSSAMCLI/bin:/c/Program Files/PostgreSQL/12/bin:/c/Users/VssAdministrator/.dotnet/tools:/c/Users/VssAdministrator/AppData/Local/Microsoft/WindowsApps
Installing MinGW-w64
/d/a/1/s/mingwCache /d/a/1/s
ERROR: i686-8.1.0-release-posix-dwarf-rt_v6-rev0.7z
i686-8.1.0-release-posix-dwarf-rt_v6-rev0.7z
Open ERROR: Can not open the file as [7z] archive


ERRORS:
Is not archive

##[error]Bash exited with code '2'.
Finishing: Install dependencies (Windows)
```
And fails.