### PR TITLE
Tag SecretKey export as distinct type

### DIFF
--- a/blscurve.nim
+++ b/blscurve.nim
@@ -12,7 +12,7 @@ import
   ./blscurve/eth2_keygen
 export
   SecretKey, PublicKey, Signature, ProofOfPossession,
-  `==`,
+  `==`, SecretByte,
   aggregate,
   sign, verify, aggregateVerify, fastAggregateVerify,
   keyGen, privToPub,

--- a/blscurve/bls_sig_io.nim
+++ b/blscurve/bls_sig_io.nim
@@ -39,16 +39,16 @@ func fromBytes*[T: SecretKey|PublicKey|Signature|ProofOfPossession](
   else:
     result = obj.point.fromBytes(raw)
 
-func toHex*(obj: SecretKey|PublicKey|Signature|ProofOfPossession): string {.inline.} =
+func toHex*(pbj: SecretKey): distinct string {.error: "Returning the hex representation of a secret key is forbidden.".}
+  ## Prevent returning the hex representation of a SecretKey
+
+func toHex*(obj: PublicKey|Signature|ProofOfPossession): string {.inline.} =
   ## Return the hex representation of a BLS signature scheme object
   ## Signature and Proof-of-posessions are serialized in compressed form
-  when obj is SecretKey:
-    result = obj.intVal.toHex()
-  else:
-    result = obj.point.toHex()
+  result = obj.point.toHex()
 
 func serialize*(
-       dst: var openarray[byte],
+       dst: var openarray[byte or SecretByte],
        obj: SecretKey|PublicKey|Signature|ProofOfPossession): bool {.inline.} =
   ## Serialize the input `obj` in raw binary form and write it
   ## in `dst`.
@@ -63,7 +63,7 @@ const
   RawPublicKeySize = MODBYTES_384
   RawSignatureSize = MODBYTES_384 * 2
 
-func exportRaw*(secretKey: SecretKey): array[RawSecretKeySize, byte] {.inline.}=
+func exportRaw*(secretKey: SecretKey): array[RawSecretKeySize, SecretByte] {.inline.}=
   ## Serialize a secret key into its raw binary representation
   # TODO: the SecretKey size is actually not 384 bit
   #       but 255 bit since the curve order requires 255-bit

--- a/blscurve/common.nim
+++ b/blscurve/common.nim
@@ -32,6 +32,8 @@ const
 
 type
   Domain* = array[8, byte]
+  SecretHex* = distinct string
+  SecretByte* = distinct byte
 
 when sizeof(int) == 4 or defined(use32):
   const
@@ -549,19 +551,20 @@ proc isOnCurve*(x: FP2_BLS12381, y: FP2_BLS12381): bool =
   else:
     result = (sqr(y) == rhs(x))
 
-proc toBytes*(a: BIG_384, res: var openarray[byte]): bool =
+proc toBytes*(a: BIG_384, res: var openarray[byte or SecretByte]): bool =
   ## Serialize big integer ``a`` to ``res``. Length of ``res`` array
   ## must be at least ``MODBYTES_384``.
   ##
   ## Returns ``true`` if ``a`` was succesfully serialized,
   ## ``false`` otherwise.
+  type B = typeof(res[0]) # byte or SecretByte
   if len(res) >= MODBYTES_384:
     var c: BIG_384
     BIG_384_copy(c, a)
     # BIG_384_norm() function in Milagro operates inplace.
     discard BIG_384_norm(c)
     for i in countdown(MODBYTES_384 - 1, 0):
-      res[i] = byte(c[0] and 0xFF)
+      res[i] = B(c[0] and 0xFF)
       discard BIG_384_fshr(c, 8)
     result = true
 


### PR DESCRIPTION
This follows a discussion with an auditor on ED25519 in libp2p.

We need to use all measures possible to prevent leaking private keys, hence I recommend that all private keys use distinct byte.
We should also prevent `toHex`, `==` on them or for `toHex` output a `SecretHex` / `SecretString`.

In nim-beacon-chain this should prevent introducing private key logging by mistake:
https://github.com/status-im/nim-beacon-chain/blob/40c2714ff30c811978fcc234f438ddd473851009/beacon_chain/spec/crypto.nim#L312-L314

Even though some thoughts was given to prevent that:
https://github.com/status-im/nim-beacon-chain/blob/40c2714ff30c811978fcc234f438ddd473851009/beacon_chain/spec/crypto.nim#L186-L187
