### PR TITLE
Fix nbc

### DIFF
--- a/blscurve.nimble
+++ b/blscurve.nimble
@@ -29,16 +29,16 @@ task test, "Run all tests":
   # test "", "tests/hash_to_curve_v7.nim"
 
   # Public BLS API - IETF standard / Ethereum2.0 v0.12.x
-  test "-d:BLS_BACKEND=miracl", "tests/eth2_vectors.nim"
+  test "-d:BLS_FORCE_BACKEND=miracl", "tests/eth2_vectors.nim"
   # key Derivation - EIP 2333
-  test "-d:BLS_BACKEND=miracl", "tests/eip2333_key_derivation.nim"
+  test "-d:BLS_FORCE_BACKEND=miracl", "tests/eip2333_key_derivation.nim"
   # Secret key to pubkey
-  test "-d:BLS_BACKEND=miracl", "tests/priv_to_pub.nim"
+  test "-d:BLS_FORCE_BACKEND=miracl", "tests/priv_to_pub.nim"
 
   when sizeof(int) == 8 and (defined(arm64) or defined(amd64)):
-    test "-d:BLS_BACKEND=blst", "tests/eth2_vectors.nim"
-    test "-d:BLS_BACKEND=blst", "tests/eip2333_key_derivation.nim"
-    test "-d:BLS_BACKEND=blst", "tests/priv_to_pub.nim"
+    test "-d:BLS_FORCE_BACKEND=blst", "tests/eth2_vectors.nim"
+    test "-d:BLS_FORCE_BACKEND=blst", "tests/eip2333_key_derivation.nim"
+    test "-d:BLS_FORCE_BACKEND=blst", "tests/priv_to_pub.nim"
 
   # # Ensure benchmarks stay relevant. Ignore Windows 32-bit at the moment
   # if not defined(windows) or not existsEnv"PLATFORM" or getEnv"PLATFORM" == "x64":

--- a/blscurve/bls_backend.nim
+++ b/blscurve/bls_backend.nim
@@ -7,19 +7,27 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-const BLS_BACKEND*{.strdefine.} = "auto"
+const BLS_FORCE_BACKEND*{.strdefine.} = "auto"
 
-static: doAssert BLS_BACKEND == "auto" or
-                 BLS_BACKEND == "miracl" or
-                 BLS_BACKEND == "blst",
-                 """Only "auto", "blst" and "miracl" backend are valid."""
+static: doAssert BLS_FORCE_BACKEND == "auto" or
+                 BLS_FORCE_BACKEND == "miracl" or
+                 BLS_FORCE_BACKEND == "blst",
+                 """Only "auto", "blst" and "miracl" backends are valid."""
 
+type BlsBackendKind* = enum
+  BLST
+  Miracl
 
 when BLS_BACKEND == "blst" or (
       BLS_BACKEND == "auto" and
         sizeof(int) == 8 and
         (defined(arm64) or defined(amd64))
     ):
+  const BLS_BACKEND* = BLST
+else:
+  const BLS_BACKEND* = Miracl
+
+when BLS_BACKEND == BLST:
   import ./blst/bls_sig_min_pubkey_size_pop
   export bls_sig_min_pubkey_size_pop
 else:

--- a/blscurve/bls_backend.nim
+++ b/blscurve/bls_backend.nim
@@ -18,8 +18,8 @@ type BlsBackendKind* = enum
   BLST
   Miracl
 
-when BLS_BACKEND == "blst" or (
-      BLS_BACKEND == "auto" and
+when BLS_FORCE_BACKEND == "blst" or (
+      BLS_FORCE_BACKEND == "auto" and
         sizeof(int) == 8 and
         (defined(arm64) or defined(amd64))
     ):

--- a/blscurve/eth2_keygen/eth2_keygen.nim
+++ b/blscurve/eth2_keygen/eth2_keygen.nim
@@ -19,7 +19,7 @@ import
   ../bls_backend,
   ./hkdf
 
-when BLS_BACKEND == "miracl":
+when BLS_BACKEND == Miracl:
   import ./hkdf_mod_r_miracl
 else:
   import ./hkdf_mod_r_blst
@@ -58,7 +58,7 @@ func parent_SK_to_lamport_PK(
 
   # 1. IKM = I2OSP(parent_SK, 32)
   var ikm {.noInit.}: array[32, byte]
-  when BLS_BACKEND == "miracl":
+  when BLS_BACKEND == Miracl:
     # While the BLS prime is 381-bit (48 bytes)
     # the curve order is 255-bit (32 bytes)
     # and a secret key would always fit in 32 bytes

--- a/blscurve/keygen_eip2333.nim
+++ b/blscurve/keygen_eip2333.nim
@@ -11,9 +11,7 @@ import ./eth2_keygen/eth2_keygen
 export eth2_keygen
 
 import ./bls_backend
-when BLS_BACKEND == "blst" or (
-  BLS_BACKEND == "auto" and (defined(arm64) or defined(amd64))
-):
+when BLS_BACKEND == BLST:
   import ./eth2_keygen/hkdf_mod_r_blst
 else:
   import ./eth2_keygen/hkdf_mod_r_miracl

--- a/blscurve/miracl/bls_sig_io.nim
+++ b/blscurve/miracl/bls_sig_io.nim
@@ -54,12 +54,13 @@ func serialize*(
   ## in `dst`.
   ## Returns `true` if the export is successful, `false` otherwise
   when obj is SecretKey:
+    # TODO: Test if dst is 32 bytes instead of 48 bytes
     result = obj.intVal.toBytes(dst)
   else:
     result = obj.point.toBytes(dst)
 
 const
-  RawSecretKeySize = MODBYTES_384
+  RawSecretKeySize = MODBYTES_384 # TODO should be 32
   RawPublicKeySize = MODBYTES_384
   RawSignatureSize = MODBYTES_384 * 2
 

--- a/tests/eip2333_key_derivation.nim
+++ b/tests/eip2333_key_derivation.nim
@@ -20,7 +20,7 @@ import
 proc toDecimal(sk: SecretKey): string =
   # The spec does not use hex but decimal ...
   var asBytes: array[32, byte]
-  when BLS_BACKEND == "miracl":
+  when BLS_BACKEND == Miracl:
     var tmp: array[48, byte]
     let ok = tmp.serialize(sk)
     doAssert ok
@@ -103,7 +103,7 @@ proc test3 =
 
   doAssert child.toDecimal == expectedChild
 
-suite "Key Derivation (EIP-2333) - " & BLS_BACKEND:
+suite "Key Derivation (EIP-2333) - " & $BLS_BACKEND:
   test "Test 0":
     test0()
   test "Test 1":

--- a/tests/eth2_vectors.nim
+++ b/tests/eth2_vectors.nim
@@ -186,6 +186,7 @@ testGen(aggregate_verify, test):
     pubkeys: seq[PublicKey]
     msgs: seq[seq[byte]]
     signature: Signature
+
   try:
     pubkey_msg_pairs = seq[(PublicKey, seq[byte])].aggFrom(test)
     pubkeys = seq[PublicKey].aggFrom(test)
@@ -211,7 +212,7 @@ testGen(aggregate_verify, test):
     "   computed: " & $libSoAValid & "\n" &
     "   expected: " & $expected
 
-suite "ETH 2.0 " & BLS_ETH2_SPEC & " test vectors - " & BLS_BACKEND:
+suite "ETH 2.0 " & BLS_ETH2_SPEC & " test vectors - " & $BLS_BACKEND:
   test "[" & BLS_ETH2_SPEC & "] sign(SecretKey, message) -> Signature":
     test_sign()
   test "[" & BLS_ETH2_SPEC & "] verify(PublicKey, message, Signature) -> bool":


### PR DESCRIPTION
keygen_eip2333 was missing a test for sizeof(int) == 8

This pR moves all the test in a single place and defines global consts instead.