### PR TITLE
check if SSSE3 is supported before enabling BLST by default on AMD64

### DIFF
--- a/blscurve/bls_backend.nim
+++ b/blscurve/bls_backend.nim
@@ -19,10 +19,12 @@ type BlsBackendKind* = enum
   Miracl
 
 when BLS_FORCE_BACKEND == "blst" or (
-      BLS_FORCE_BACKEND == "auto" and
-        sizeof(int) == 8 and
-        (defined(arm64) or defined(amd64))
-    ):
+  BLS_FORCE_BACKEND == "auto" and
+    sizeof(int) == 8 and
+    (defined(arm64) or (
+      defined(amd64) and
+      gorgeEx("gcc -march=native -dM -E -x c /dev/null | grep -q SSSE3").exitCode == 0))
+  ):
   const BLS_BACKEND* = BLST
 else:
   const BLS_BACKEND* = Miracl

--- a/blscurve/bls_backend.nim
+++ b/blscurve/bls_backend.nim
@@ -7,6 +7,8 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+import os
+
 const BLS_FORCE_BACKEND*{.strdefine.} = "auto"
 
 static: doAssert BLS_FORCE_BACKEND == "auto" or
@@ -23,7 +25,7 @@ when BLS_FORCE_BACKEND == "blst" or (
     sizeof(int) == 8 and
     (defined(arm64) or (
       defined(amd64) and
-      gorgeEx("gcc -march=native -dM -E -x c /dev/null | grep -q SSSE3").exitCode == 0))
+      gorgeEx(getEnv("CC", "gcc") & " -march=native -dM -E -x c /dev/null | grep -q SSSE3").exitCode == 0))
   ):
   const BLS_BACKEND* = BLST
 else:


### PR DESCRIPTION
See https://github.com/status-im/nim-beacon-chain/issues/1555