### PR TITLE
Update BLST

### DIFF
--- a/benchmarks/bench_sha256.nim
+++ b/benchmarks/bench_sha256.nim
@@ -1,0 +1,36 @@
+import
+  # Stdlib
+  std/[random, sequtils],
+  # Status
+  nimcrypto/[sha2, hash],
+  # BLSCurve
+  ../blscurve/bls_backend,
+  # Bench
+  ./bench_templates
+
+static: doAssert BLS_BACKEND == BLST
+
+var rng = initRand(int64 0xDECAF)
+
+proc benchSHA256_nimcrypto[T](msg: openarray[T], msgComment: string, iters: int) =
+  var digest: MDigest[256]
+  bench("SHA256 - " & msgComment & " - nimcrypto", iters):
+    digest = sha256.digest(msg)
+
+proc benchSHA256_blst[T](msg: openarray[T], msgComment: string, iters: int) =
+  var digest: array[32, byte]
+  bench("SHA256 - " & msgComment & " - BLST", iters):
+    digest.bls_sha256_digest(msg)
+
+when isMainModule:
+  proc main() =
+    block:
+      let msg5MB = newSeqWith(5_000_000, byte rng.rand(255))
+      benchSHA256_nimcrypto(msg5MB, "5MB", 16)
+      benchSHA256_blst(msg5MB, "5MB", 16)
+    block:
+      let msg128B = newSeqWith(128, byte rng.rand(255))
+      benchSHA256_nimcrypto(msg128B, "128B", 128)
+      benchSHA256_blst(msg128B, "128B", 128)
+
+  main()

--- a/benchmarks/bench_templates.nim
+++ b/benchmarks/bench_templates.nim
@@ -59,9 +59,9 @@ proc report(op: string, start, stop: MonoTime, startClk, stopClk: int64, iters: 
   let ns = inNanoseconds((stop-start) div iters)
   let throughput = 1e9 / float64(ns)
   when SupportsGetTicks:
-    echo &"{op:<52}     {throughput:>10.3f} ops/s    {ns:>9} ns/op    {(stopClk - startClk) div iters:>9} cycles"
+    echo &"{op:<52}     {throughput:>15.3f} ops/s    {ns:>9} ns/op    {(stopClk - startClk) div iters:>9} cycles"
   else:
-    echo &"{op:<52}     {throughput:>10.3f} ops/s    {ns:>9} ns/op"
+    echo &"{op:<52}     {throughput:>15.3f} ops/s    {ns:>9} ns/op"
 
 template bench*(op: string, iters: int, body: untyped): untyped =
   let start = getMonotime()

--- a/blscurve.nimble
+++ b/blscurve.nimble
@@ -45,6 +45,9 @@ task test, "Run all tests":
     test "-d:BLS_FORCE_BACKEND=blst", "tests/eip2333_key_derivation.nim"
     test "-d:BLS_FORCE_BACKEND=blst", "tests/priv_to_pub.nim"
 
+    # Internal SHA256
+    test "-d:BLS_FORCE_BACKEND=blst", "tests/blst_sha256.nim"
+
   # # Ensure benchmarks stay relevant. Ignore Windows 32-bit at the moment
   # if not defined(windows) or not existsEnv"PLATFORM" or getEnv"PLATFORM" == "x64":
   #   exec "nim c -d:danger --outdir:build -r" &

--- a/blscurve/bls_backend.nim
+++ b/blscurve/bls_backend.nim
@@ -27,8 +27,15 @@ when BLS_FORCE_BACKEND == "blst" or (
       defined(amd64) and
       gorgeEx(getEnv("CC", "gcc") & " -march=native -dM -E -x c /dev/null | grep -q SSSE3").exitCode == 0))
   ):
+  # BLST supports: x86_64 and ARM64
+  # and has optimized SHA256 routines for x86_64 CPU with SSE3
   const BLS_BACKEND* = BLST
+elif BLS_FORCE_BACKEND == "auto" and defined(amd64):
+  # CPU doesn't support SSE3 which is used in optimized SHA256
+  const BLS_BACKEND* = BLST
+  {.passC: "-D__BLST_PORTABLE__".}
 else:
+  # Pure C fallback for all platforms
   const BLS_BACKEND* = Miracl
 
 when BLS_BACKEND == BLST:

--- a/blscurve/bls_backend.nim
+++ b/blscurve/bls_backend.nim
@@ -39,8 +39,8 @@ else:
   const BLS_BACKEND* = Miracl
 
 when BLS_BACKEND == BLST:
-  import ./blst/bls_sig_min_pubkey_size_pop
-  export bls_sig_min_pubkey_size_pop
+  import ./blst/bls_sig_min_pubkey_size_pop, ./blst/sha256_abi
+  export bls_sig_min_pubkey_size_pop, sha256_abi
 else:
   import
     ./miracl/bls_signature_scheme

--- a/blscurve/blst/blst_abi.nim
+++ b/blscurve/blst/blst_abi.nim
@@ -122,12 +122,12 @@ type
 
   blst_pairing* {.incompleteStruct, blst.} = object
 
-# var
-#   # Generators
-#   BLS12_381_G1* {.blst.}: blst_p1_affine
-#   BLS12_381_NEG_G1* {.blst.}: blst_p1_affine
-#   BLS12_381_G2* {.blst.}: blst_p2_affine
-#   BLS12_381_NEG_G2* {.blst.}: blst_p2_affine
+var
+  # Generators
+  BLS12_381_G1* {.blst.}: blst_p1_affine
+  BLS12_381_NEG_G1* {.blst.}: blst_p1_affine
+  BLS12_381_G2* {.blst.}: blst_p2_affine
+  BLS12_381_NEG_G2* {.blst.}: blst_p2_affine
 
 {.push cdecl, importc, header: headerPath.}
 

--- a/blscurve/blst/blst_lowlevel.nim
+++ b/blscurve/blst/blst_lowlevel.nim
@@ -9,14 +9,6 @@
 
 import std/os
 
-when defined(gcc):
-  # * Using ftree-loop-vectorize will miscompile scalar multiplication
-  #   for example used to derive the public key in blst_sk_to_pk_in_g1
-  # * Using ftree-slp-vectorize miscompiles something when used
-  #   in nim-beacon-chain in Travis CI (TODO: test case)
-  # no-tree-vectorize removes both
-  {.passC: "-fno-tree-vectorize".}
-
 {.compile: ".."/".."/"vendor"/"blst"/"build"/"assembly.S".}
 {.compile: ".."/".."/"vendor"/"blst"/"src"/"server.c".}
 

--- a/blscurve/blst/sha256_abi.nim
+++ b/blscurve/blst/sha256_abi.nim
@@ -1,0 +1,37 @@
+# This file exposes the internal assembly optimized SHA256 routines
+# of BLST.
+
+import std/[strutils, os]
+
+const srcPath = currentSourcePath.rsplit(DirSep, 1)[0]/".."/".."/"vendor"/"blst"/"src"
+const headerPath = srcPath/"sha256.h"
+
+type
+  BLST_SHA256_CTX* {.
+    importc: "SHA256_CTX",
+    header: headerPath,
+    incompleteStruct, byref.} = object
+
+proc vec_zero(ret: pointer, num: csize_t)
+    {.importc, exportc, header: srcPath/"vect.h", nodecl.}
+
+proc blst_sha256_init*(ctx: var BLST_SHA256_CTX)
+     {.importc: "sha256_init", header: headerPath, cdecl.}
+
+proc blst_sha256_update*[T: byte|char](
+       ctx: var BLST_SHA256_CTX,
+       input: openarray[T]
+     ){.importc: "sha256_update", header: headerPath, cdecl.}
+
+proc blst_sha256_final*(
+       digest: var array[32, byte],
+       ctx: var BLST_SHA256_CTX
+     ){.importc: "sha256_final", header: headerPath, cdecl.}
+
+proc bls_sha256_digest*[T: byte|char](
+       digest: var array[32, byte],
+       input: openarray[T]) =
+  var ctx{.noInit.}: BLST_SHA256_CTX
+  ctx.blst_sha256_init()
+  ctx.blst_sha256_update(input)
+  digest.blst_sha256_final(ctx)

--- a/tests/blst_sha256.nim
+++ b/tests/blst_sha256.nim
@@ -22,7 +22,6 @@ proc test() =
   let a = sha256.digest(input)
 
   var b{.noInit.}: array[32, byte]
-  doAssert a.data != b
   b.bls_sha256_digest(input)
   doAssert a.data == b
 

--- a/tests/blst_sha256.nim
+++ b/tests/blst_sha256.nim
@@ -1,0 +1,32 @@
+import
+  # Stdlib
+  std/[unittest, random, sequtils, times],
+  # Status
+  nimcrypto/[sha2, hash],
+  # BLSCurve
+  ../blscurve/bls_backend
+
+static: doAssert BLS_BACKEND == BLST
+
+const Iters = 128
+
+let seed = uint32(getTime().toUnix() and (1'i64 shl 32 - 1)) # unixTime mod 2^32
+var rng = initRand(int64 seed)
+echo "\n------------------------------------------------------\n"
+echo "test_bls_sha256 xoshiro128+ (std/random) seed: ", seed
+
+proc test() =
+  let inputLen = rng.rand(128)
+  let input = newSeqWith(inputLen, byte rng.rand(255))
+
+  let a = sha256.digest(input)
+
+  var b{.noInit.}: array[32, byte]
+  doAssert a.data != b
+  b.bls_sha256_digest(input)
+  doAssert a.data == b
+
+suite "BLST internal SHA256 vs nimcrypto":
+  test "BLST internal SHA256 vs nimcrypto":
+    for _ in 0 ..< Iters:
+      test()


### PR DESCRIPTION
This updates BLST from commit 
Reference diff:
- Before https://github.com/supranational/blst/tree/6e0190c from Jul 13, 2020
- After https://github.com/supranational/blst/tree/a8398ed from Sep 17, 2020
- https://github.com/supranational/blst/compare/6e0190c...a8398ed

State

- [x] Support APi changes from https://github.com/supranational/blst/pull/9
- [x] Remove vectorization aliasing workaround from #69, https://github.com/status-im/nim-blscurve/commit/2317e9ceac3378f9540bbbbc0b1fdbaf73808a9b, partly address #84
      Upstream: https://github.com/supranational/blst/issues/22, and probably related https://github.com/supranational/blst/commit/f8a77bd97fd9318efab20725f3a4b068a1842e85
- [x] Change the workaround from https://github.com/status-im/nim-blscurve/commit/da9ae49dab4cbb95b2cdaa68ecc221ee15c67a9a to pass `-D__BLST_PORTABLE__` instead of falling back to Milagro if the CPU doesn't support SSE3
- [x] Expose the optimized SHA256 primitives for use in hashTreeRoot