### PR TITLE
Bump BLST - backend perf improvements

### DIFF
--- a/blscurve/blst/bls_sig_min_pubkey_size_pop.nim
+++ b/blscurve/blst/bls_sig_min_pubkey_size_pop.nim
@@ -16,7 +16,14 @@
 #   approach, since the size of (PK_1, ..., PK_n, signature) is
 #   dominated by the public keys even for small n.
 
-# We expose the same API as nim-blscurve
+# We expose the same API as MIRACL
+#
+# Design:
+# - We check public keys and signatures at deserialization
+#   - non-zero
+#   - in the correct subgroup
+#   The primitives called assume that input are already subgroup-checked
+#   and so do not call "KeyValidate" again in verification procs.
 
 import
   # Status libraries
@@ -167,6 +174,8 @@ func fromBytes*(
     let pa = cast[ptr array[L, byte]](raw[0].unsafeAddr)
     obj.scalar.blst_scalar_from_bendian(pa[])
   if obj.vec_is_zero():
+    return false
+  if not obj.scalar.blst_sk_check().bool:
     return false
   return true
 

--- a/blscurve/blst/blst_abi.nim
+++ b/blscurve/blst/blst_abi.nim
@@ -140,6 +140,7 @@ proc blst_bendian_from_scalar*(ret: var array[32, byte]; a: blst_scalar)
 proc blst_scalar_from_lendian*(ret: var blst_scalar; a: array[32, byte])
 proc blst_lendian_from_scalar*(ret: var array[32, byte]; a: blst_scalar)
 proc blst_scalar_fr_check*(a: blst_scalar): CTBool
+proc blst_sk_check*(a: blst_scalar): CTBool
 
 # BLS12-381-specific Fr operations (Modulo curve order)
 proc blst_fr_add*(ret: var blst_fr; a: blst_fr; b: blst_fr)


### PR DESCRIPTION
This bumps BLST to the latest master.

Since BLSv4 commit which is the current one nimbus ETH2 builds with we have the following improvements:
(https://github.com/status-im/nim-blscurve/compare/3878b9b...master)

- Group checks can now be done at deserialization only and are now optional at BLS verification time.
  This is how we use Milagro already and we paid unnecessary group checks with BLST until now.
  With fast subgroup checks the cost of those checks isn't that high,1/4 to 1/2 of a scalar multiplication https://github.com/status-im/nim-blst/issues/1, https://github.com/mratsim/constantine/issues/47, which is significantly less costly than pairing but when a block is filled with 128 attestations it's still significant. Probable perf improvement 8~18% (maybe more?). https://github.com/supranational/blst/pull/44
- A specialized secret check commit https://github.com/supranational/blst/commit/6bd1da51359dcb73cac3f9a2b79f9b14f6ebc9bb
- An optimized inversion, the costliest operation after square root, and used in the prelude of all pairings, using state-of-the-art research by Thomas Pornin https://eprint.iacr.org/2020/972
- BLST now has a pure C backend hence we do not need to use MIRACL anymore.

And the current bump also brings
- A significant 2.5x perf boost in Fp2 square root which translate to 40% speed improvement in hash to G2 and should translate to about 15% perf improvement in verification as verification = 1/3 hash-to-G2 and 2/3 pairings (https://github.com/status-im/nim-blst/issues/1)
