### PR TITLE
Use the new BLST no assembly fallback on 32-bit

### DIFF
--- a/blscurve.nim
+++ b/blscurve.nim
@@ -7,7 +7,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-const BLS_ETH2_SPEC* = "v1.0.0-rc0"
+const BLS_ETH2_SPEC* = "v1.0.0"
 import
   blscurve/bls_backend,
   blscurve/keygen_eip2333

--- a/blscurve.nim
+++ b/blscurve.nim
@@ -7,7 +7,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-const BLS_ETH2_SPEC* = "v1.0.0"
+const BLS_ETH2_SPEC* = "v1.0.0-rc0"
 import
   blscurve/bls_backend,
   blscurve/keygen_eip2333

--- a/blscurve.nimble
+++ b/blscurve.nimble
@@ -38,12 +38,14 @@ task test, "Run all tests":
   # Secret key to pubkey
   test "-d:BLS_FORCE_BACKEND=miracl", "tests/priv_to_pub.nim"
 
-  test "-d:BLS_FORCE_BACKEND=blst", "tests/eth2_vectors.nim"
-  test "-d:BLS_FORCE_BACKEND=blst", "tests/eip2333_key_derivation.nim"
-  test "-d:BLS_FORCE_BACKEND=blst", "tests/priv_to_pub.nim"
+  when defined(arm64) or defined(arm) or
+       defined(amd64) or defined(i386):
+    test "-d:BLS_FORCE_BACKEND=blst", "tests/eth2_vectors.nim"
+    test "-d:BLS_FORCE_BACKEND=blst", "tests/eip2333_key_derivation.nim"
+    test "-d:BLS_FORCE_BACKEND=blst", "tests/priv_to_pub.nim"
 
-  # Internal SHA256
-  test "-d:BLS_FORCE_BACKEND=blst", "tests/blst_sha256.nim"
+    # Internal SHA256
+    test "-d:BLS_FORCE_BACKEND=blst", "tests/blst_sha256.nim"
 
   # # Ensure benchmarks stay relevant. Ignore Windows 32-bit at the moment
   # if not defined(windows) or not existsEnv"PLATFORM" or getEnv"PLATFORM" == "x64":

--- a/blscurve.nimble
+++ b/blscurve.nimble
@@ -31,20 +31,19 @@ task test, "Run all tests":
   # Internal BLS API - IETF standard
   # test "", "tests/hash_to_curve_v7.nim"
 
-  # Public BLS API - IETF standard / Ethereum2.0 v0.12.x
+  # Public BLS API - IETF standard / Ethereum2.0 v1.0.0
   test "-d:BLS_FORCE_BACKEND=miracl", "tests/eth2_vectors.nim"
   # key Derivation - EIP 2333
   test "-d:BLS_FORCE_BACKEND=miracl", "tests/eip2333_key_derivation.nim"
   # Secret key to pubkey
   test "-d:BLS_FORCE_BACKEND=miracl", "tests/priv_to_pub.nim"
 
-  when sizeof(int) == 8 and (defined(arm64) or defined(amd64)):
-    test "-d:BLS_FORCE_BACKEND=blst", "tests/eth2_vectors.nim"
-    test "-d:BLS_FORCE_BACKEND=blst", "tests/eip2333_key_derivation.nim"
-    test "-d:BLS_FORCE_BACKEND=blst", "tests/priv_to_pub.nim"
+  test "-d:BLS_FORCE_BACKEND=blst", "tests/eth2_vectors.nim"
+  test "-d:BLS_FORCE_BACKEND=blst", "tests/eip2333_key_derivation.nim"
+  test "-d:BLS_FORCE_BACKEND=blst", "tests/priv_to_pub.nim"
 
-    # Internal SHA256
-    test "-d:BLS_FORCE_BACKEND=blst", "tests/blst_sha256.nim"
+  # Internal SHA256
+  test "-d:BLS_FORCE_BACKEND=blst", "tests/blst_sha256.nim"
 
   # # Ensure benchmarks stay relevant. Ignore Windows 32-bit at the moment
   # if not defined(windows) or not existsEnv"PLATFORM" or getEnv"PLATFORM" == "x64":

--- a/blscurve/bls_backend.nim
+++ b/blscurve/bls_backend.nim
@@ -9,23 +9,28 @@
 
 import os
 
-const BLS_FORCE_BACKEND*{.strdefine.} = "blst"
+const BLS_FORCE_BACKEND*{.strdefine.} = "auto"
 
-static: doAssert BLS_FORCE_BACKEND == "miracl" or
+static: doAssert BLS_FORCE_BACKEND == "auto" or
+                 BLS_FORCE_BACKEND == "miracl" or
                  BLS_FORCE_BACKEND == "blst",
-                 """Only blst" and "miracl" backends are valid."""
+                 """Only "auto", "blst" and "miracl" backends are valid."""
 
 type BlsBackendKind* = enum
   BLST
   Miracl
 
-when BLS_FORCE_BACKEND == "blst" and (
-      gorgeEx(getEnv("CC", "gcc") & " -march=native -dM -E -x c /dev/null | grep -q SSSE3").exitCode == 0
+when BLS_FORCE_BACKEND == "blst" or (
+  BLS_FORCE_BACKEND == "auto" and
+    sizeof(int) == 8 and
+    (defined(arm64) or (
+      defined(amd64) and
+      gorgeEx(getEnv("CC", "gcc") & " -march=native -dM -E -x c /dev/null | grep -q SSSE3").exitCode == 0))
   ):
   # BLST supports: x86_64 and ARM64
   # and has optimized SHA256 routines for x86_64 CPU with SSE3
   const BLS_BACKEND* = BLST
-elif BLS_FORCE_BACKEND == "blst":
+elif BLS_FORCE_BACKEND == "auto" and defined(amd64):
   # CPU doesn't support SSE3 which is used in optimized SHA256
   const BLS_BACKEND* = BLST
   {.passC: "-D__BLST_PORTABLE__".}

--- a/blscurve/bls_backend.nim
+++ b/blscurve/bls_backend.nim
@@ -20,18 +20,23 @@ type BlsBackendKind* = enum
   BLST
   Miracl
 
-when BLS_FORCE_BACKEND == "blst" or (
-  BLS_FORCE_BACKEND == "auto" and
-    sizeof(int) == 8 and
-    (defined(arm64) or (
-      defined(amd64) and
-      gorgeEx(getEnv("CC", "gcc") & " -march=native -dM -E -x c /dev/null | grep -q SSSE3").exitCode == 0))
+const AutoSelectBLST = BLS_FORCE_BACKEND == "auto" and (
+  defined(arm64) or defined(arm) or
+  defined(amd64) or defined(i386)
+)
+# Theoretically the BLST library has a fallback for any platform
+# but it is missing https://github.com/supranational/blst/issues/46
+
+when (BLS_FORCE_BACKEND == "blst" or AutoSelectBLST) and (
+  gorgeEx(getEnv("CC", "gcc") & " -march=native -dM -E -x c /dev/null | grep -q SSSE3").exitCode == 0) or
   ):
-  # BLST supports: x86_64 and ARM64
+  # BLST supports: x86 and ARM 32 and 64 bits
   # and has optimized SHA256 routines for x86_64 CPU with SSE3
+  # It also assumes that all ARM CPUs are Neon instructions capable for SHA256
   const BLS_BACKEND* = BLST
-elif BLS_FORCE_BACKEND == "auto" and defined(amd64):
+elif BLS_FORCE_BACKEND == "blst" or AutoSelectBLST:
   # CPU doesn't support SSE3 which is used in optimized SHA256
+  # BLST_PORTABLE is a no-op on ARM
   const BLS_BACKEND* = BLST
   {.passC: "-D__BLST_PORTABLE__".}
 else:

--- a/blscurve/bls_backend.nim
+++ b/blscurve/bls_backend.nim
@@ -28,7 +28,7 @@ const AutoSelectBLST = BLS_FORCE_BACKEND == "auto" and (
 # but it is missing https://github.com/supranational/blst/issues/46
 
 when (BLS_FORCE_BACKEND == "blst" or AutoSelectBLST) and (
-  gorgeEx(getEnv("CC", "gcc") & " -march=native -dM -E -x c /dev/null | grep -q SSSE3").exitCode == 0) or
+  gorgeEx(getEnv("CC", "gcc") & " -march=native -dM -E -x c /dev/null | grep -q SSSE3").exitCode == 0
   ):
   # BLST supports: x86 and ARM 32 and 64 bits
   # and has optimized SHA256 routines for x86_64 CPU with SSE3

--- a/blscurve/bls_backend.nim
+++ b/blscurve/bls_backend.nim
@@ -9,28 +9,23 @@
 
 import os
 
-const BLS_FORCE_BACKEND*{.strdefine.} = "auto"
+const BLS_FORCE_BACKEND*{.strdefine.} = "blst"
 
-static: doAssert BLS_FORCE_BACKEND == "auto" or
-                 BLS_FORCE_BACKEND == "miracl" or
+static: doAssert BLS_FORCE_BACKEND == "miracl" or
                  BLS_FORCE_BACKEND == "blst",
-                 """Only "auto", "blst" and "miracl" backends are valid."""
+                 """Only blst" and "miracl" backends are valid."""
 
 type BlsBackendKind* = enum
   BLST
   Miracl
 
-when BLS_FORCE_BACKEND == "blst" or (
-  BLS_FORCE_BACKEND == "auto" and
-    sizeof(int) == 8 and
-    (defined(arm64) or (
-      defined(amd64) and
-      gorgeEx(getEnv("CC", "gcc") & " -march=native -dM -E -x c /dev/null | grep -q SSSE3").exitCode == 0))
+when BLS_FORCE_BACKEND == "blst" and (
+      gorgeEx(getEnv("CC", "gcc") & " -march=native -dM -E -x c /dev/null | grep -q SSSE3").exitCode == 0
   ):
   # BLST supports: x86_64 and ARM64
   # and has optimized SHA256 routines for x86_64 CPU with SSE3
   const BLS_BACKEND* = BLST
-elif BLS_FORCE_BACKEND == "auto" and defined(amd64):
+elif BLS_FORCE_BACKEND == "blst":
   # CPU doesn't support SSE3 which is used in optimized SHA256
   const BLS_BACKEND* = BLST
   {.passC: "-D__BLST_PORTABLE__".}


### PR DESCRIPTION
The new BLST has a no-assembly fallback for non-ARM64 non-AMD64 targets.
Hence we can no use BLST instead of Miracl/Milagro throughough.