### PR TITLE
BLST no ASM flag for non-x86 non-ARM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
   # Temporary patch for https://github.com/supranational/blst/issues/46#issuecomment-738939501
   - pushd vendor/blst
   - git fetch https://github.com/dot-asm/blst no-asm-as-command-line
-  - git cherry-pick 8e37f9e14306f39ae5417cd223112b5d20656d49
+  - git -c user.name=Nobody -c user.email=nobody@example.com cherry-pick 8e37f9e14306f39ae5417cd223112b5d20656d49
   - popd
 
   - nimble test

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,11 @@ script:
   # testing only
   - nimble install https://github.com/status-im/NimYAML@#head # Cannot clone upstream https://github.com/flyx/NimYAML/issues/77
   - nimble install stint
+
+  # Temporary patch for https://github.com/supranational/blst/issues/46#issuecomment-738939501
+  - pushd vendor/blst
+  - git fetch https://github.com/dot-asm/blst no-asm-as-command-line
+  - git cherry-pick 8e37f9e14306f39ae5417cd223112b5d20656d49
+  - popd
+
   - nimble test

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,4 @@ script:
   # testing only
   - nimble install https://github.com/status-im/NimYAML@#head # Cannot clone upstream https://github.com/flyx/NimYAML/issues/77
   - nimble install stint
-
-  # Temporary patch for https://github.com/supranational/blst/issues/46#issuecomment-738939501
-  - pushd vendor/blst
-  - git fetch https://github.com/dot-asm/blst no-asm-as-command-line
-  - git -c user.name=Nobody -c user.email=nobody@example.com cherry-pick 8e37f9e14306f39ae5417cd223112b5d20656d49
-  - popd
-
   - nimble test

--- a/blscurve.nimble
+++ b/blscurve.nimble
@@ -38,14 +38,12 @@ task test, "Run all tests":
   # Secret key to pubkey
   test "-d:BLS_FORCE_BACKEND=miracl", "tests/priv_to_pub.nim"
 
-  when defined(arm64) or defined(arm) or
-       defined(amd64) or defined(i386):
-    test "-d:BLS_FORCE_BACKEND=blst", "tests/eth2_vectors.nim"
-    test "-d:BLS_FORCE_BACKEND=blst", "tests/eip2333_key_derivation.nim"
-    test "-d:BLS_FORCE_BACKEND=blst", "tests/priv_to_pub.nim"
+  test "-d:BLS_FORCE_BACKEND=blst", "tests/eth2_vectors.nim"
+  test "-d:BLS_FORCE_BACKEND=blst", "tests/eip2333_key_derivation.nim"
+  test "-d:BLS_FORCE_BACKEND=blst", "tests/priv_to_pub.nim"
 
-    # Internal SHA256
-    test "-d:BLS_FORCE_BACKEND=blst", "tests/blst_sha256.nim"
+  # Internal SHA256
+  test "-d:BLS_FORCE_BACKEND=blst", "tests/blst_sha256.nim"
 
   # Ensure benchmarks stay relevant.
   # TODO, solve "inconsistent operand constraints"

--- a/blscurve/bls_backend.nim
+++ b/blscurve/bls_backend.nim
@@ -20,12 +20,7 @@ type BlsBackendKind* = enum
   BLST
   Miracl
 
-const AutoSelectBLST = BLS_FORCE_BACKEND == "auto" and (
-  defined(arm64) or defined(arm) or
-  defined(amd64) or defined(i386)
-)
-# Theoretically the BLST library has a fallback for any platform
-# but it is missing https://github.com/supranational/blst/issues/46
+const AutoSelectBLST = BLS_FORCE_BACKEND == "auto"
 
 when (BLS_FORCE_BACKEND == "blst" or AutoSelectBLST) and (
   gorgeEx(getEnv("CC", "gcc") & " -march=native -dM -E -x c /dev/null | grep -q SSSE3").exitCode == 0

--- a/blscurve/bls_backend.nim
+++ b/blscurve/bls_backend.nim
@@ -20,23 +20,36 @@ type BlsBackendKind* = enum
   BLST
   Miracl
 
-const AutoSelectBLST = BLS_FORCE_BACKEND == "auto"
+const UseBLST = BLS_FORCE_BACKEND == "auto" or BLS_FORCE_BACKEND == "blst"
+const OnX86 = defined(i386) or defined(amd64)
+const OnARM = defined(arm) or defined(arm64)
 
-when (BLS_FORCE_BACKEND == "blst" or AutoSelectBLST) and (
-  gorgeEx(getEnv("CC", "gcc") & " -march=native -dM -E -x c /dev/null | grep -q SSSE3").exitCode == 0
-  ):
-  # BLST supports: x86 and ARM 32 and 64 bits
-  # and has optimized SHA256 routines for x86_64 CPU with SSE3
-  # It also assumes that all ARM CPUs are Neon instructions capable for SHA256
+when UseBLST:
+  when OnX86:
+    # BLST defaults to SSE3 for SHA256 (Pentium 4, 2004)
+    # And autodetects MULX and ADCX/ADOX for bigints (Intel Broadwell 2015, AMD Ryzen 2017)
+    # It is set either via -march=native on a proper CPU
+    # or -madx
+    const useSSE3 = gorgeEx(getEnv("CC", "gcc") & " -march=native -dM -E -x c /dev/null | grep -q SSSE3").exitCode == 0
+    when not useSSE3:
+      {.passC: "-D__BLST_PORTABLE__".}
+  elif OnARM:
+    # On ARM, BLST can use hardware SHA256.
+    # This is the case for all ARM 64-bit device except Raspberry Pis.
+    # BLST detects at compile-time the support via
+    # the __ARM_FEATURE_CRYPTO compile-time define
+    #
+    # It is set either with -march=native on a proper CPU
+    # or -march=armv8-a+crypto
+    # and can be disabled with -D__BLST_PORTABLE__
+
+    # {.passC: "-D__BLST_PORTABLE__".}
+    discard
+  else:
+    {.passC: "-D__BLST_NO_ASM__".}
   const BLS_BACKEND* = BLST
-elif BLS_FORCE_BACKEND == "blst" or AutoSelectBLST:
-  # CPU doesn't support SSE3 which is used in optimized SHA256
-  # On ARM, BLST_PORTABLE will prevent use builtin SHA256
-  # which is unsupported by Raspberry Pi, detection via (__ARM_FEATURE_CRYPTO)
-  const BLS_BACKEND* = BLST
-  {.passC: "-D__BLST_PORTABLE__".}
 else:
-  # Pure C fallback for all platforms
+  # Miracl
   const BLS_BACKEND* = Miracl
 
 when BLS_BACKEND == BLST:


### PR DESCRIPTION
This tests the suggested patch https://github.com/supranational/blst/issues/46#issuecomment-738939501
for a no assembly fallback.

In https://github.com/status-im/nim-blscurve/pull/96 we could use BLS on non x86 and non ARM 64-bit target as the #if #elif branch where missing that case.

The relevant test to check is Travis PowerPC 64.

~~This uses a patch that isn't upstream in travis.yml~~

The patch has been successfully tested and integrated in the master branch of BLST.
So this PR bumps BLST and uses it on non-x86, non-ARM. THis seems to work on Travis on PowerPC64.

This means that there is no reason to continue maintaining the Miracl backend, especially once BLST completes their security audit and formal verification. Unless we want a fallback for things like https://github.com/status-im/nimbus-eth2/pull/1753 but even then we can force pass the BLST_NO_ASM flag.