### PR TITLE
Cached group checks

### DIFF
--- a/blscurve/blst/blst_abi.nim
+++ b/blscurve/blst/blst_abi.nim
@@ -120,7 +120,42 @@ type
     x*: blst_fp2
     y*: blst_fp2
 
-  blst_pairing* {.incompleteStruct, blst.} = object
+type
+  AggregatedSignature {.union.} = object
+    e1: blst_p1
+    e2: blst_p2
+
+  blst_pairing* = object
+    # "blst_pairing" in header is defined as
+    # an empty struct. This forces usage on the heap
+    # through pointer.
+    # We want to use the true definition in aggregate.c
+    # to allow stack allocation.
+    # Since the definition is private to aggregate.c
+    # we have to rewrite it in Nim.
+    #
+    #ifndef N_MAX
+    # define N_MAX 8
+    #endif
+    # typedef union { POINTonE1 e1; POINTonE2 e2; } AggregatedSignature;
+    # typedef struct {
+    #     unsigned int ctrl;
+    #     unsigned int nelems;
+    #     const void *DST;
+    #     size_t DST_len;
+    #     vec384fp12 GT;
+    #     AggregatedSignature AggrSign;
+    #     POINTonE2_affine Q[N_MAX];
+    #     POINTonE1_affine P[N_MAX];
+    # } PAIRING;
+    ctrl: cuint
+    nelems: cuint
+    DST: pointer
+    DST_len: csize_t
+    GT: blst_fp12
+    AggrSign: AggregatedSignature
+    Q: array[8, blst_p2_affine]
+    P: array[8, blst_p1_affine]
 
 var
   # Generators


### PR DESCRIPTION
This uses the new primitives mentioned in #92 for cached group checks.

Now we check at deserialization:
- if a pubkey is infinity or not in the subgroup
- if a signature is not in the subgroup (we may deserialize empty signatures)

Instead of checking that at verification time. Since public keys are reused multiple time this is a significant performance improvement.

New perf
![image](https://user-images.githubusercontent.com/22738317/101246912-84b20700-3716-11eb-88b7-988fe191842f.png)

In #97 we had
![image](https://user-images.githubusercontent.com/22738317/101246926-a4492f80-3716-11eb-97e1-28f644ac4ee0.png)

So we cumulated a total of (4025212-4588537)/(4588537) = 12.2% perf improvement compared to the current BLST in Nimbus.

Closes #42 as well