### PR TITLE
Parallel and Serial batch verification

### DIFF
--- a/benchmarks/bench_all.nim
+++ b/benchmarks/bench_all.nim
@@ -24,3 +24,19 @@ benchHashToG2(1000)
 benchSign(1000)
 benchVerify(1000)
 benchFastAggregateVerify(numKeys = 128, iters = 10)
+
+when BLS_BACKEND == BLST:
+  # Simulate Block verification
+  batchVerifyMulti(numSigs = 6, iters = 10)
+  batchVerifyMultiBatchedSerial(numSigs = 6, iters = 6)
+  batchVerifyMultiBatchedParallel(numSigs = 6, iters = 1)
+
+  # Simulate 10 blocks verification
+  batchVerifyMulti(numSigs = 60, iters = 10)
+  batchVerifyMultiBatchedSerial(numSigs = 60, iters = 10)
+  batchVerifyMultiBatchedParallel(numSigs = 60, iters = 10)
+
+  # Simulate 30 blocks verification
+  batchVerifyMulti(numSigs = 180, iters = 10)
+  batchVerifyMultiBatchedSerial(numSigs = 180, iters = 10)
+  batchVerifyMultiBatchedParallel(numSigs = 180, iters = 10)

--- a/benchmarks/bench_all.nim
+++ b/benchmarks/bench_all.nim
@@ -2,13 +2,15 @@ import
   ../blscurve,
   ./bls12381_curve,
   ./hash_to_curve,
-  ./bls_signature
+  ./bls_signature,
+  ./bench_templates
 
 # Curve operations
 benchScalarMultG1(1000)
 benchScalarMultG2(1000)
 benchEcAddG1(1000)
 benchEcAddG2(1000)
+separator()
 
 # Pairings
 when BLS_BACKEND == BLST:
@@ -16,27 +18,33 @@ when BLS_BACKEND == BLST:
 else:
   benchMiraclPairingViaDoublePairing(1000)
   benchMiraclPairingViaMultiPairing(1000)
+separator()
 
 # Hash-to-curve implementation
 benchHashToG2(1000)
+separator()
 
 # High-level BLS signature scheme
 benchSign(1000)
 benchVerify(1000)
 benchFastAggregateVerify(numKeys = 128, iters = 10)
+separator()
 
 when BLS_BACKEND == BLST:
   # Simulate Block verification
   batchVerifyMulti(numSigs = 6, iters = 10)
   batchVerifyMultiBatchedSerial(numSigs = 6, iters = 6)
   batchVerifyMultiBatchedParallel(numSigs = 6, iters = 1)
+  separator()
 
   # Simulate 10 blocks verification
   batchVerifyMulti(numSigs = 60, iters = 10)
   batchVerifyMultiBatchedSerial(numSigs = 60, iters = 10)
   batchVerifyMultiBatchedParallel(numSigs = 60, iters = 10)
+  separator()
 
   # Simulate 30 blocks verification
   batchVerifyMulti(numSigs = 180, iters = 10)
   batchVerifyMultiBatchedSerial(numSigs = 180, iters = 10)
   batchVerifyMultiBatchedParallel(numSigs = 180, iters = 10)
+  separator()

--- a/benchmarks/bench_all.nim
+++ b/benchmarks/bench_all.nim
@@ -32,9 +32,9 @@ separator()
 
 when BLS_BACKEND == BLST:
   # Simulate Block verification
-  batchVerifyMulti(numSigs = 6, iters = 10)
-  batchVerifyMultiBatchedSerial(numSigs = 6, iters = 6)
-  batchVerifyMultiBatchedParallel(numSigs = 6, iters = 1)
+  batchVerifyMulti(numSigs = 6, iters = 100)
+  batchVerifyMultiBatchedSerial(numSigs = 6, iters = 100)
+  batchVerifyMultiBatchedParallel(numSigs = 6, iters = 100)
   separator()
 
   # Simulate 10 blocks verification

--- a/benchmarks/bench_sha256.nim
+++ b/benchmarks/bench_sha256.nim
@@ -4,7 +4,7 @@ import
   # Status
   nimcrypto/[sha2, hash],
   # BLSCurve
-  ../blscurve/bls_backend,
+  ../blscurve/bls_public_exports,
   # Bench
   ./bench_templates
 

--- a/benchmarks/bench_templates.nim
+++ b/benchmarks/bench_templates.nim
@@ -53,6 +53,9 @@ when SupportsGetTicks:
 echo "\nBackend: ", $BLS_BACKEND, ", mode: ", if defined(use32): $32 else: $(sizeof(int) * 8), "-bit"
 echo "=".repeat(132) & '\n'
 
+proc separator*() =
+  echo "-".repeat(132)
+
 proc report(op: string, start, stop: MonoTime, startClk, stopClk: int64, iters: int) =
   let ns = inNanoseconds((stop-start) div iters)
   let throughput = 1e9 / float64(ns)

--- a/benchmarks/bench_templates.nim
+++ b/benchmarks/bench_templates.nim
@@ -51,15 +51,15 @@ when SupportsGetTicks:
   echo "i.e. a 20% overclock will be about 20% off (assuming no dynamic frequency scaling)"
 
 echo "\nBackend: ", $BLS_BACKEND, ", mode: ", if defined(use32): $32 else: $(sizeof(int) * 8), "-bit"
-echo "=================================================================================================================\n"
+echo "=".repeat(132) & '\n'
 
 proc report(op: string, start, stop: MonoTime, startClk, stopClk: int64, iters: int) =
   let ns = inNanoseconds((stop-start) div iters)
   let throughput = 1e9 / float64(ns)
   when SupportsGetTicks:
-    echo &"{op:<52}     {throughput:>15.3f} ops/s    {ns:>9} ns/op    {(stopClk - startClk) div iters:>9} cycles"
+    echo &"{op:<67}     {throughput:>15.3f} ops/s    {ns:>9} ns/op    {(stopClk - startClk) div iters:>9} cycles"
   else:
-    echo &"{op:<52}     {throughput:>15.3f} ops/s    {ns:>9} ns/op"
+    echo &"{op:<67}     {throughput:>15.3f} ops/s    {ns:>9} ns/op"
 
 template bench*(op: string, iters: int, body: untyped): untyped =
   let start = getMonotime()

--- a/benchmarks/bls_signature.nim
+++ b/benchmarks/bls_signature.nim
@@ -52,21 +52,21 @@ proc benchVerify*(iters: int) =
     let valid = pk.verify(msg, sig)
     # doAssert valid
 
+proc keyGen(): tuple[pk: PublicKey, sk: SecretKey] =
+  var ikm: array[32, byte]
+  for b in ikm.mitems:
+    b = byte benchRNG.rand(0xFF)
+  doAssert ikm.keyGen(result.pk, result.sk)
+
 proc benchFastAggregateVerify*(numKeys, iters: int) =
+  ## Verification of N pubkeys signing for 1 message
   let msg = "Mr F was here"
 
   var validators = newSeq[PublicKey](numKeys)
   var aggSig: AggregateSignature
 
   for i in 0 ..< numKeys:
-    var pk: PublicKey
-    var sk: SecretKey
-    var ikm: array[32, byte]
-
-    for b in ikm.mitems:
-      b = byte benchRNG.rand(0xFF)
-    doAssert ikm.keyGen(pk, sk)
-
+    let (pk, sk) = keyGen()
     validators[i] = pk
 
     let sig = sk.sign(msg)
@@ -81,9 +81,80 @@ proc benchFastAggregateVerify*(numKeys, iters: int) =
 
   bench("BLS agg verif of 1 msg by " & $numKeys & " pubkeys", iters):
     let valid = validators.fastAggregateVerify(msg, finalSig)
-    doAssert valid
+    # doAssert valid
+
+when BLS_BACKEND == BLST:
+  proc batchVerifyMulti*(numSigs, iters: int) =
+    ## Verification of N pubkeys signing for N messages
+
+    var triplets: seq[tuple[pubkey: PublicKey, msg: array[32, byte], sig: Signature]]
+
+    for i in 0 ..< numSigs:
+      let (pk, sk) = keyGen()
+      var hashedMsg: array[32, byte]
+      hashedMsg.bls_sha256_digest("msg" & $i)
+      triplets.add (pk, hashedMsg, sk.sign(hashedMsg))
+
+    bench("BLS verif of " & $numSigs & " msgs by "& $numSigs & " pubkeys", iters):
+      for i in 0 ..< triplets.len:
+        let ok = triplets[i].pubkey.verify(triplets[i].msg, triplets[i].sig)
+        doAssert ok
+
+  proc batchVerifyMultiBatchedSerial*(numSigs, iters: int) =
+    ## Verification of N pubkeys signing for N messages
+
+    var batcher = init(BatchedBLSVerifier[32])
+
+    for i in 0 ..< numSigs:
+      let (pk, sk) = keyGen()
+      var hashedMsg: array[32, byte]
+      hashedMsg.bls_sha256_digest("msg" & $i)
+      doAssert batcher.incl(pk, hashedMsg, sk.sign(hashedMsg))
+
+    var secureBlindingBytes: array[32, byte]
+    secureBlindingBytes.bls_sha256_digest("Mr F was here")
+
+    bench("Serial batch verify " & $numSigs & " msgs by "& $numSigs & " pubkeys (with blinding)", iters):
+      secureBlindingBytes.bls_sha256_digest(secureBlindingBytes)
+      let ok = batcher.batchVerifySerial(secureBlindingBytes)
+      # doAssert ok
+
+  proc batchVerifyMultiBatchedParallel*(numSigs, iters: int) =
+    ## Verification of N pubkeys signing for N messages
+
+    var batcher = init(BatchedBLSVerifier[32])
+
+    for i in 0 ..< numSigs:
+      let (pk, sk) = keyGen()
+      var hashedMsg: array[32, byte]
+      hashedMsg.bls_sha256_digest("msg" & $i)
+      doAssert batcher.incl(pk, hashedMsg, sk.sign(hashedMsg))
+
+    var secureBlindingBytes: array[32, byte]
+    secureBlindingBytes.bls_sha256_digest("Mr F was here")
+
+    bench("Parallel batch verify of " & $numSigs & " msgs by " & $numSigs & " pubkeys (with blinding)", iters):
+      secureBlindingBytes.bls_sha256_digest(secureBlindingBytes)
+      let ok = batcher.batchVerifyParallel(secureBlindingBytes)
+      # doAssert ok
 
 when isMainModule:
   benchSign(1000)
   benchVerify(1000)
   benchFastAggregateVerify(numKeys = 128, iters = 10)
+
+  when BLS_BACKEND == BLST:
+    # Simulate Block verification
+    batchVerifyMulti(numSigs = 6, iters = 10)
+    batchVerifyMultiBatchedSerial(numSigs = 6, iters = 10)
+    batchVerifyMultiBatchedParallel(numSigs = 6, iters = 10)
+
+    # Simulate 10 blocks verification
+    batchVerifyMulti(numSigs = 60, iters = 10)
+    batchVerifyMultiBatchedSerial(numSigs = 60, iters = 10)
+    batchVerifyMultiBatchedParallel(numSigs = 60, iters = 10)
+
+    # Simulate 30 blocks verification
+    batchVerifyMulti(numSigs = 180, iters = 10)
+    batchVerifyMultiBatchedSerial(numSigs = 180, iters = 10)
+    batchVerifyMultiBatchedParallel(numSigs = 180, iters = 10)

--- a/benchmarks/bls_signature.nim
+++ b/benchmarks/bls_signature.nim
@@ -103,7 +103,7 @@ when BLS_BACKEND == BLST:
   proc batchVerifyMultiBatchedSerial*(numSigs, iters: int) =
     ## Verification of N pubkeys signing for N messages
 
-    var batcher = init(BatchedBLSVerifier[32])
+    var batcher = init(BatchedBLSVerifier)
 
     for i in 0 ..< numSigs:
       let (pk, sk) = keyGen()
@@ -122,7 +122,7 @@ when BLS_BACKEND == BLST:
   proc batchVerifyMultiBatchedParallel*(numSigs, iters: int) =
     ## Verification of N pubkeys signing for N messages
 
-    var batcher = init(BatchedBLSVerifier[32])
+    var batcher = init(BatchedBLSVerifier)
 
     for i in 0 ..< numSigs:
       let (pk, sk) = keyGen()

--- a/benchmarks/bls_signature.nim
+++ b/benchmarks/bls_signature.nim
@@ -101,13 +101,13 @@ when BLS_BACKEND == BLST:
   proc batchVerifyMultiBatchedSerial*(numSigs, iters: int) =
     ## Verification of N pubkeys signing for N messages
 
-    var batcher = init(BatchedBLSVerifier)
+    var batcher = init(BatchedBLSVerifierCache)
 
     for i in 0 ..< numSigs:
       let (pk, sk) = keyGen()
       var hashedMsg: array[32, byte]
       hashedMsg.bls_sha256_digest("msg" & $i)
-      doAssert batcher.incl(pk, hashedMsg, sk.sign(hashedMsg))
+      batcher.add(pk, hashedMsg, sk.sign(hashedMsg))
 
     var secureBlindingBytes: array[32, byte]
     secureBlindingBytes.bls_sha256_digest("Mr F was here")
@@ -119,13 +119,13 @@ when BLS_BACKEND == BLST:
   proc batchVerifyMultiBatchedParallel*(numSigs, iters: int) =
     ## Verification of N pubkeys signing for N messages
 
-    var batcher = init(BatchedBLSVerifier)
+    var batcher = init(BatchedBLSVerifierCache)
 
     for i in 0 ..< numSigs:
       let (pk, sk) = keyGen()
       var hashedMsg: array[32, byte]
       hashedMsg.bls_sha256_digest("msg" & $i)
-      doAssert batcher.incl(pk, hashedMsg, sk.sign(hashedMsg))
+      batcher.add(pk, hashedMsg, sk.sign(hashedMsg))
 
     var secureBlindingBytes: array[32, byte]
     secureBlindingBytes.bls_sha256_digest("Mr F was here")

--- a/benchmarks/bls_signature.nim
+++ b/benchmarks/bls_signature.nim
@@ -50,7 +50,6 @@ proc benchVerify*(iters: int) =
 
   bench("BLS verification", iters):
     let valid = pk.verify(msg, sig)
-    # doAssert valid
 
 proc keyGen(): tuple[pk: PublicKey, sk: SecretKey] =
   var ikm: array[32, byte]
@@ -81,7 +80,6 @@ proc benchFastAggregateVerify*(numKeys, iters: int) =
 
   bench("BLS agg verif of 1 msg by " & $numKeys & " pubkeys", iters):
     let valid = validators.fastAggregateVerify(msg, finalSig)
-    # doAssert valid
 
 when BLS_BACKEND == BLST:
   proc batchVerifyMulti*(numSigs, iters: int) =
@@ -117,7 +115,6 @@ when BLS_BACKEND == BLST:
     bench("Serial batch verify " & $numSigs & " msgs by "& $numSigs & " pubkeys (with blinding)", iters):
       secureBlindingBytes.bls_sha256_digest(secureBlindingBytes)
       let ok = batcher.batchVerifySerial(secureBlindingBytes)
-      # doAssert ok
 
   proc batchVerifyMultiBatchedParallel*(numSigs, iters: int) =
     ## Verification of N pubkeys signing for N messages
@@ -136,7 +133,6 @@ when BLS_BACKEND == BLST:
     bench("Parallel batch verify of " & $numSigs & " msgs by " & $numSigs & " pubkeys (with blinding)", iters):
       secureBlindingBytes.bls_sha256_digest(secureBlindingBytes)
       let ok = batcher.batchVerifyParallel(secureBlindingBytes)
-      # doAssert ok
 
 when isMainModule:
   benchSign(1000)

--- a/blscurve.nimble
+++ b/blscurve.nimble
@@ -45,13 +45,13 @@ task test, "Run all tests":
   # Internal SHA256
   test "-d:BLS_FORCE_BACKEND=blst", "tests/blst_sha256.nim"
 
-    # batch verification
-    test "-d:BLS_FORCE_BACKEND=blst", "tests/t_batch_verifier.nim"
+  # batch verification
+  test "-d:BLS_FORCE_BACKEND=blst", "tests/t_batch_verifier.nim"
 
-    # No OpenMP in default Clang on Mac
-    when not defined(macosx):
-      # Parallel batch verification
-      test "-d:openmp -d:BLS_FORCE_BACKEND=blst", "tests/t_batch_verifier.nim"
+  # No OpenMP in default Clang on Mac
+  when not defined(macosx):
+    # Parallel batch verification
+    test "-d:openmp -d:BLS_FORCE_BACKEND=blst", "tests/t_batch_verifier.nim"
 
   # Ensure benchmarks stay relevant.
   # TODO, solve "inconsistent operand constraints"

--- a/blscurve.nimble
+++ b/blscurve.nimble
@@ -45,6 +45,14 @@ task test, "Run all tests":
   # Internal SHA256
   test "-d:BLS_FORCE_BACKEND=blst", "tests/blst_sha256.nim"
 
+    # batch verification
+    test "-d:BLS_FORCE_BACKEND=blst", "tests/t_batch_verifier.nim"
+
+    # No OpenMP in default Clang on Mac
+    when not defined(macosx):
+      # Parallel batch verification
+      test "-d:openmp -d:BLS_FORCE_BACKEND=blst", "tests/t_batch_verifier.nim"
+
   # Ensure benchmarks stay relevant.
   # TODO, solve "inconsistent operand constraints"
   # on 32-bit for asm volatile, this might be due to

--- a/blscurve.nimble
+++ b/blscurve.nimble
@@ -70,6 +70,6 @@ task bench, "Run benchmarks":
   if not dirExists "build":
     mkDir "build"
 
-  exec "nim c -d:danger --outdir:build -r" &
+  exec "nim c -d:openmp -d:danger --outdir:build -r" &
          " --verbosity:0 --hints:off --warnings:off" &
          " benchmarks/bench_all.nim"

--- a/blscurve.nimble
+++ b/blscurve.nimble
@@ -58,13 +58,22 @@ task test, "Run all tests":
   # on 32-bit for asm volatile, this might be due to
   # incorrect RDTSC call in benchmark
   when defined(arm64) or defined(amd64):
-    exec "nim c -d:BLS_FORCE_BACKEND=miracl -d:danger --outdir:build -r" &
-          " --verbosity:0 --hints:off --warnings:off" &
-          " benchmarks/bench_all.nim"
+    when not defined(macosx):
+      exec "nim c -d:openmp -d:BLS_FORCE_BACKEND=miracl -d:danger --outdir:build -r" &
+            " --verbosity:0 --hints:off --warnings:off" &
+            " benchmarks/bench_all.nim"
 
-    exec "nim c -d:BLS_FORCE_BACKEND=blst -d:danger --outdir:build -r" &
-          " --verbosity:0 --hints:off --warnings:off" &
-          " benchmarks/bench_all.nim"
+      exec "nim c -d:openmp -d:BLS_FORCE_BACKEND=blst -d:danger --outdir:build -r" &
+            " --verbosity:0 --hints:off --warnings:off" &
+            " benchmarks/bench_all.nim"
+    else:
+      exec "nim c -d:BLS_FORCE_BACKEND=miracl -d:danger --outdir:build -r" &
+            " --verbosity:0 --hints:off --warnings:off" &
+            " benchmarks/bench_all.nim"
+
+      exec "nim c -d:BLS_FORCE_BACKEND=blst -d:danger --outdir:build -r" &
+            " --verbosity:0 --hints:off --warnings:off" &
+            " benchmarks/bench_all.nim"
 
 task bench, "Run benchmarks":
   if not dirExists "build":

--- a/blscurve/bls_batch_verifier.nim
+++ b/blscurve/bls_batch_verifier.nim
@@ -308,7 +308,6 @@ proc batchVerifyParallel*(
   # Stage 1: Accumulate partial pairings
   checksAndStackTracesOff:
     omp_parallel: # Start the parallel region
-      attachGC()
       let threadID = omp_get_thread_num()
       omp_chunks(numSets, chunkStart, chunkLen):
         # Partition work into even chunks

--- a/blscurve/bls_batch_verifier.nim
+++ b/blscurve/bls_batch_verifier.nim
@@ -291,8 +291,6 @@ proc batchVerifyParallel*(
     # Spec precondition
     return false
 
-  # TODO: tuning, is 1 set per thread worth it?
-  # or do we need a minimum like 2 per thread?
   let numBatches = min(numSets, omp_get_max_threads().uint32)
 
   # Stage 0: Accumulators - setLen for noinit of seq

--- a/blscurve/bls_batch_verifier.nim
+++ b/blscurve/bls_batch_verifier.nim
@@ -123,7 +123,7 @@ func add*(
 # ----------------------------------------------------------------------
 
 func batchVerifySerial*(
-       batcher: BatchedBLSVerifierCache,
+       batcher: var BatchedBLSVerifierCache,
        secureRandomBytes: array[32, byte]
      ): bool =
   ## Single-threaded batch verification
@@ -133,7 +133,7 @@ func batchVerifySerial*(
 
   batcher.batchContexts.setLen(1)
   template ctx: untyped = batcher.batchContexts[0]
-  ctx.init()
+  batcher.batchContexts[0].init(secureRandomBytes, "")
 
   # Accumulate line functions
   for i in 0 ..< batcher.sets.len:

--- a/blscurve/bls_batch_verifier.nim
+++ b/blscurve/bls_batch_verifier.nim
@@ -90,7 +90,7 @@ func incl*[HashLen: static int](
        public_keys: openarray[PublicKey],
        message: array[HashLen, byte],
        signature: Signature
-     ): bool {.inline.} =
+     ): bool =
   ## Include a (array of public keys, message, signature) triplet
   ## to the batch for verification.
   ##

--- a/blscurve/bls_batch_verifier.nim
+++ b/blscurve/bls_batch_verifier.nim
@@ -1,0 +1,376 @@
+# Nim-BLSCurve
+# Copyright (c) 2018-Present Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  ./bls_backend, ./bls_sig_min_pubkey,
+  ./openmp
+
+# BLS Batch Verifier
+# ----------------------------------------------------------------------
+# We use OpenMP here but might want to use a simple threadpool
+# for portability as Mac compiler doesn't ship with OpenMP
+# and while MSVC has OpenMP, it's unsure about Mingw
+#
+# Also as Nim supports for view types and openarray in object fields is experimental
+# we collect/copy the inputs in the object for now by copy.
+# instead of accumulating them in a pairing context.
+# Note that a pairing context is 3+MB
+# while we have
+# - publickey = 48B
+# - signature = 96B
+# - message = 32B (assuming sha256 hashed)
+# hence 176B only
+#
+# TODO: Once ContextMultiAggregateVerify is implemented
+# for Milagro/Miracl, this wouldn't need to be in the BLST specific file
+
+type
+  SignatureSet[HashLen: static int] = object
+    ## A (Public Key, Message, Signature) triplet
+    ## that will be batch verified.
+    ## This should not hold GC-ed memory
+    ## as this would complexify multithreading.
+    ## Consequently this assumes that message
+    ## is the output of a fixed size hash function.
+    signature: Signature
+    pubkey: PublicKey
+    message: array[HashLen, byte]
+
+  BatchedBLSVerifier*[HashLen: static int] = object
+    ## A type to batch BLS multi signatures (aggregated or individual)
+    ## verification using multiple cores if compiled with OpenMP
+    sets: seq[SignatureSet[HashLen]]
+
+    # Per-batch contexts for multithreaded batch verification
+    batchContexts: seq[ContextMultiAggregateVerify[DST]]
+
+func init*(T: type BatchedBLSVerifier): T {.inline.} =
+  ## Initialize or reinitialize a batchedBLS Verifier
+  # Impl: A BatchedBLSVerifier still MUST be zero-init
+  # otherwise the sequences fields
+  # like capacity and reserve memory will be wrong.
+  result.sets.setLen(0)
+  result.batchContexts.setLen(0)
+
+func clear*(batcher: var BatchedBLSVerifier) {.inline.} =
+  ## Initialize or reinitialize a batchedBLS Verifier
+  batcher.sets.setLen(0)
+  batcher.batchContexts.setLen(0)
+
+func incl*[HashLen: static int](
+       batcher: var BatchedBLSVerifier[HashLen],
+       public_key: PublicKey,
+       message: array[HashLen, byte],
+       signature: Signature
+     ): bool {.inline.} =
+  ## Include a (public key, message, signature) triplet
+  ## to the batch for verification.
+  ##
+  ## Always return true
+  ##
+  ## The proof-of-possession MUST be verified before calling this function.
+  ## It is recommended to use the overload that accepts a proof-of-possession
+  ## to enforce correct usage.
+  batcher.sets.add SignatureSet[HashLen](
+    signature: signature,
+    pubkey: public_key,
+    message: message
+  )
+  return true
+
+func incl*[HashLen: static int](
+       batcher: var BatchedBLSVerifier[HashLen],
+       public_keys: openarray[PublicKey],
+       message: array[HashLen, byte],
+       signature: Signature
+     ): bool {.inline.} =
+  ## Include a (array of public keys, message, signature) triplet
+  ## to the batch for verification.
+  ##
+  ## All public keys sign the same message
+  ## and signature is their aggregated signature
+  ##
+  ## Returns false if no public keys are passed
+  ## Returns true otherwise
+  ##
+  ## The proof-of-possession MUST be verified before calling this function.
+  ## It is recommended to use the overload that accepts a proof-of-possession
+  ## to enforce correct usage.
+  if publicKeys.len == 0:
+    return false
+
+  var aggAffine{.noInit.}: PublicKey
+  if not aggAffine.aggregateAll(publicKeys):
+    return false
+
+  batcher.sets.add SignatureSet(
+    signature: signature,
+    pubkey: aggAffine,
+    message: message
+  )
+
+# Serial Batch Verifier
+# ----------------------------------------------------------------------
+
+func batchVerifySerial*(
+       batcher: BatchedBLSVerifier,
+       secureRandomBytes: array[32, byte]
+     ): bool =
+  ## Single-threaded batch verification
+  if batcher.sets.len == 0:
+    return false
+
+  var ctx {.noInit.}: ContextMultiAggregateVerify[DST]
+  ctx.init(
+    secureRandomBytes,
+    threadSepTag = ""
+  )
+
+  # Accumulate line functions
+  for i in 0 ..< batcher.sets.len:
+    let ok = ctx.update(
+      batcher.sets[i].pubkey,
+      batcher.sets[i].message,
+      batcher.sets[i].signature
+    )
+    if not ok:
+      return false
+
+  # Miller loop
+  ctx.commit()
+
+  # Final exponentiation
+  return ctx.finalVerify()
+
+# Parallelized Batch Verifier
+# ----------------------------------------------------------------------
+
+# No Nim checks in OpenMP multithreading land, failure allocates an exception.
+# No stacktraces either.
+# Also use uint instead of int to ensure no range checks.
+{.push stacktrace:off, checks: off.}
+
+func toPtrUncheckedArray[T](s: seq[T]): ptr UncheckedArray[T] {.inline.} =
+  {.pragma: restrict, codegenDecl: "$# __restrict $#".}
+  let ident{.restrict.} = cast[
+    ptr UncheckedArray[T]](
+      s[0].unsafeAddr()
+  )
+
+func accumPairingLines[HashLen](
+       sigsets: ptr UncheckedArray[SignatureSet[HashLen]],
+       contexts: ptr UncheckedArray[ContextMultiAggregateVerify[DST]],
+       batchID: uint32,
+       subsetStart: uint32,
+       subsetStopEx: uint32): bool =
+  ## Accumulate pairing lines
+  ## subsetStopEx is iteration stopping index, non-inclusive
+  ## Assumes that contexts[batchID] is valid.
+  ## Assumes that sigsets[subsetStart..<subsetStopEx] is valid
+  for i in subsetStart ..< subsetStopEx:
+    let ok = contexts[batchID].update(
+        sigsets[i].pubkey,
+        sigsets[i].message,
+        sigsets[i].signature
+      )
+    if not ok:
+      return false
+
+  contexts[batchID].commit()
+
+func dacPairing[HashLen](
+       sigsets: ptr UncheckedArray[SignatureSet[HashLen]],
+       contexts: ptr UncheckedArray[ContextMultiAggregateVerify[DST]],
+       numBatches: uint32,
+       batchID: uint32,
+       subsetStart: uint32,
+       subsetStopEx: uint32
+     ): bool =
+  ## Distribute pairing computation using a recursive divide-and-conquer (DAC) algorithm
+  ##
+  ## Returns false if at least one partial pairing `update` failed.
+  ## ⚠️ : We use 0-based indexing for the tree splitting
+  ##                  root at 0    root at 1
+  ## Left child        ix*2 + 1     ix*2
+  ## Right child       ix*2 + 2     ix*2 + 1
+  ## Parent            (ix-1)/2     ix/2
+  #
+  # Rationale for divide and conquer.
+  # Parallel pairing computation requires the following steps
+  #
+  # Assuming we have N (public key, message, signature) triplets to verify
+  # on P processor/threads.
+  # We want B batches with B = P
+  # Each processing W work items with W = N/B or N/B + 1
+  #
+  # Step 0: Initialize a context per parallel batch.
+  # Step 1: Compute partial pairings, W work items per thread.
+  # Step 2: Merge the B partial pairings
+  #
+  # For step 2 we have 2 strategies.
+  # Strategy A: a simple linear merge
+  # ```
+  # for i in 1 ..< N:
+  #   contexts[0].merge(contexts[i])
+  # ```
+  # which requires B operations.
+  # In that case we can get away with just a simple parallel for loop.
+  # and a serial linear merge for step 2
+  #
+  # Strategy B: A divide-and-conquer algorithm
+  # We binary split the merge until we hit the base case:
+  # ```
+  # contexts[i].merge(contexts[i+1])
+  # ```
+  #
+  # As pairing merge (Fp12 multiplication) is costly
+  # (~10000 CPU cycles on Skylake-X with ADCX/ADOX instructions)
+  # and for Ethereum we would at least have 6 sets:
+  # - block proposals signatures
+  # - randao reveal signatures
+  # - proposser slashings signatures
+  # - attester slashings signatures
+  # - attestations signatures
+  # - validator exits signatures
+  # not counting deposits signatures which may be invalid
+  # The merging would be 60k cycles if linear
+  # or 10k * log2(6) = 30k cycles if divide-and-conquer on 6+ cores
+  # Note that as the tree processing progresses, less threads are required
+  # for full parallelism so even with less than 6 cores, the speedup should be important.
+  #
+  # Hence we prefer strategy B. It would also be easier to port to a simple threadpool
+  # which doesn't support parallel for loop but do support plain task spawning.
+  #
+  # That said a pairing is about 3400k cycles so the optimization is only noticeable
+  # when we do multi-block batches,
+  # for example batching 20 blocks would require 1200k cycles for a linear merge.
+  #
+  # Since we use divide-and-conquer for step 2, we might as well use it for step 1 as well
+  # which would also allow us to remove synchronization barriers between step 1 and 2.
+  # - 1 for the master thread to check ctx.update(...) results and early return
+  # - 1 to ensure that the contextPtr array is fully updated before starting merge
+  #
+  # Note: Skylake-X is a very recent family, with bigint instructions MULX/ADCX/ADOX,
+  # multiply everything by 2~3 on a Raspberry Pi
+  # and scale by core frequency.
+  # 3000 cycles is 1ms at 3GHz.
+
+  # Overflow check: numBatches and so batchID*2+2 are capped by number of threads
+  template left(batchID: uint32): uint32 = 2*batchID+1
+  template right(batchID: uint32): uint32 = 2*batchID+2
+
+  let mid = (subsetStopEx+subsetStart) shr 1
+
+  if subsetStopEx-subsetStart <= 1 or batchID.left >= numBatches:
+    # Can't split or no need to split anymore
+    # as there is more work than hardware threads/batches
+    # and it's better to accumulate as much as possible in partial pairings
+    # as merge cost is non-trivial (10k to 20k cycles).
+    # So we want 1 merge per thread and no more.
+    let ok = accumPairingLines(sigsets, contexts,
+                               batchID, subsetStart, subsetStopEx)
+    if not ok:
+      return false
+    return true
+  elif batchID.right >= numBatches:
+    # No need to split, there is no right subtree
+    # We directly accumulate in the current batch context
+    let ok = accumPairingLines(sigsets, contexts,
+                               batchID, subsetStart, mid)
+    if not ok:
+      return false
+    return true
+  else:
+    # Split in half, distribute the right and work on the left
+    var leftOk, rightOk = true
+    omp_task"":
+      rightOk = dacPairing(sigsets, contexts, numBatches,
+                           batchID.right(), mid, subsetStopEx)
+    leftOk = dacPairing(sigsets, contexts, numBatches,
+                        batchID.left(), subsetStart, mid)
+
+    # Wait for all subtrees
+    omp_taskwait()
+    if not leftOk or not rightOk:
+      return false
+    # Merge left and right
+    let mergeOk = contexts[batchID.left()].merge(contexts[batchID.right()])
+    if not mergeOk:
+      return false
+    # Update our own pairing context - 3+MB copy
+    contexts[batchID] = contexts[batchID.left()]
+    return true
+
+{.pop.}
+
+proc batchVerifyParallel*(
+       batcher: var BatchedBLSVerifier,
+       secureRandomBytes: array[32, byte]
+     ): bool {.sideeffect.} =
+  ## Multithreaded batch verification
+  ## Requires OpenMP 3.0 (GCC 4.4, 2008)
+  let numSets = batcher.sets.len.uint32
+  if numSets == 0:
+    return false
+
+  let numBatches = min(numSets, omp_get_num_threads().uint32)
+
+  # Stage 0: Accumulators - setLen for noinit of seq
+  batcher.batchContexts.setLen(numBatches.int)
+
+  # No stacktrace, exception
+  # or anything that require a GC in a parallel section
+  # otherwise "attachGC()" is needed in the parallel prologue
+  # Hence we use raw ptr UncheckedArray instead of seq
+  let contextsPtr = batcher.batchContexts.toPtrUncheckedArray()
+  let setsPtr = batcher.sets.toPtrUncheckedArray()
+
+  var ok: bool
+  {.push stacktrace:off, checks:off.}
+  omp_parallel:
+    let threadID = omp_get_thread_num()
+
+    contextsPtr[threadID].init(
+      secureRandomBytes,
+      threadSepTag = cast[array[sizeof(cint), byte]](threadID)
+    )
+
+    omp_single:
+      ok = dacPairing(setsPtr, contextsPtr, numBatches,
+                      batchID = 0, subsetStart = 0, subsetStopEx = numSets)
+  {.pop.}
+
+  if not ok:
+    return false
+
+  return batcher.batchContexts[0].finalVerify()
+
+# Autoselect Batch Verifier
+# ----------------------------------------------------------------------
+
+proc batchVerify*(
+       batcher: var BatchedBLSVerifier,
+       secureRandomBytes: array[32, byte]
+     ): bool =
+  ## Verify all signatures in batch at once.
+  ## Returns true if all signatures are correct
+  ## Returns false if there is at least one incorrect signature
+  ##
+  ## This requires securely generated random bytes
+  ## for scalar blinding
+  ## to defend against forged signatures that would not
+  ## verify individually but would verify while aggregated.
+  ##
+  ## The blinding scheme also assumes that the attacker cannot
+  ## resubmit 2^64 times forged (publickey, message, signature) triplets
+  ## against the same `secureRandomBytes`
+  if min(batcher.sets.len.uint32, omp_get_num_threads().uint32) >= 2:
+    batcher.batchVerifyParallel(secureRandomBytes)
+  else:
+    batcher.batchVerifySerial(secureRandomBytes)

--- a/blscurve/bls_public_exports.nim
+++ b/blscurve/bls_public_exports.nim
@@ -27,3 +27,6 @@ export
 when BLS_BACKEND == BLST:
   import ./blst/sha256_abi
   export sha256_abi
+
+  import ./bls_batch_verifier
+  export bls_batch_verifier

--- a/blscurve/bls_sig_min_pubkey.nim
+++ b/blscurve/bls_sig_min_pubkey.nim
@@ -28,7 +28,7 @@ import bls_backend
 # Compared to the spec API are modified
 # to enforce usage of the proof-of-posession (as recommended)
 
-const DST = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_"
+const DST* = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_"
 const DST_POP = "BLS_POP_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_"
 
 func popProve*(secretKey: SecretKey, publicKey: PublicKey): ProofOfPossession =

--- a/blscurve/bls_sig_min_pubkey.nim
+++ b/blscurve/bls_sig_min_pubkey.nim
@@ -138,6 +138,7 @@ func aggregateVerify*(
   if publicKeys.len != proofs.len or publicKeys != messages.len:
     return false
   if not(publicKeys.len >= 1):
+    # Spec precondition
     return false
 
   var ctx{.noInit.}: ContextCoreAggregateVerify[DST]
@@ -164,6 +165,7 @@ func aggregateVerify*(
   if publicKeys.len != messages.len:
     return false
   if not(publicKeys.len >= 1):
+    # Spec precondition
     return false
 
   var ctx{.noInit.}: ContextCoreAggregateVerify[DST]
@@ -185,6 +187,7 @@ func aggregateVerify*[T: string or seq[byte]](
   ## to enforce correct usage.
   # Note: we can't have tuple of openarrays until openarrays are first-class value types
   if not(publicKey_msg_pairs.len >= 1):
+    # Spec precondition
     return false
 
   var ctx{.noInit.}: ContextCoreAggregateVerify[DST]
@@ -212,6 +215,7 @@ func fastAggregateVerify*[T: byte|char](
   # 5. PK = point_to_pubkey(aggregate)
   # 6. return CoreVerify(PK, message, signature)
   if publicKeys.len == 0:
+    # Spec precondition
     return false
   if not publicKeys[0].popVerify(proofs[0]):
     return false
@@ -245,6 +249,7 @@ func fastAggregateVerify*[T: byte|char](
   # 5. PK = point_to_pubkey(aggregate)
   # 6. return CoreVerify(PK, message, signature)
   if publicKeys.len == 0:
+    # Spec precondition
     return false
 
   var aggAffine{.noInit.}: PublicKey

--- a/blscurve/blst/blst_min_pubkey_sig_core.nim
+++ b/blscurve/blst/blst_min_pubkey_sig_core.nim
@@ -178,6 +178,7 @@ template genAggregatorProcedures(
     ## Returns false if `elems` is the empty array
     ## and true otherwise
     if len(elems) == 0:
+      # Spec precondition
       return false
     var agg{.noInit.}: Aggregate
     agg.init(elems[0])

--- a/blscurve/blst/blst_min_pubkey_sig_core.nim
+++ b/blscurve/blst/blst_min_pubkey_sig_core.nim
@@ -447,7 +447,7 @@ func init*[T: char|byte](
        ctx: var ContextMultiAggregateVerify,
        secureRandomBytes: array[32, byte],
        threadSepTag: openarray[T]
-     ) {.inline.} =
+     ) =
   ## initialize a multi-signature aggregate verification context
   ## This requires cryptographically secure random bytes
   ## to defend against forged signatures that would not
@@ -463,19 +463,22 @@ func init*[T: char|byte](
     ctx.DomainSepTag
   ) # C1 = 1 (identity element)
 
-  var mixer: BLST_SHA256_CTX
-  mixer.init()
-  mixer.update(secureRandomBytes)
-  mixer.update(threadSepTag)
-
-  ctx.secureBlinding.finalize(mixer)
+  if threadSepTag.len > 0:
+    ctx.secureBlinding.bls_sha256_digest(
+      secureRandomBytes,
+      threadSepTag
+    )
+  else:
+    ctx.secureBlinding.bls_sha256_digest(
+      secureRandomBytes
+    )
 
 func update*[T: char|byte](
          ctx: var ContextMultiAggregateVerify,
          publicKey: PublicKey,
          message: openarray[T],
          signature: Signature
-       ): bool {.inline.} =
+       ): bool =
   ## Add a (public key, message, signature) triplet
   ## to a ContextMultiAggregateVerify context
   ##

--- a/blscurve/blst/blst_min_pubkey_sig_core.nim
+++ b/blscurve/blst/blst_min_pubkey_sig_core.nim
@@ -463,7 +463,12 @@ func init*[T: char|byte](
     ctx.DomainSepTag
   ) # C1 = 1 (identity element)
 
-  ctx.secureBlinding = secureRandomBytes
+  var mixer: BLST_SHA256_CTX
+  mixer.init()
+  mixer.update(secureRandomBytes)
+  mixer.update(threadSepTag)
+
+  ctx.secureBlinding.finalize(mixer)
 
 func update*[T: char|byte](
          ctx: var ContextMultiAggregateVerify,

--- a/blscurve/blst/blst_min_pubkey_sig_core.nim
+++ b/blscurve/blst/blst_min_pubkey_sig_core.nim
@@ -516,6 +516,12 @@ func update*[T: char|byte](
     aug = ""
   )
 
+## No Nim checks in OpenMP multithreading land, failure allocates an exception.
+## No stacktraces either.
+## For debugging a parallel OpenMP region, put "attachGC"
+## as the first statement after "omp_parallel"
+## Then you can echo strings and reenable stacktraces
+{.push stacktrace:off, checks: off.}
 func commit*(ctx: var ContextMultiAggregateVerify) {.inline.} =
   ## Consolidate all init/update operations done so far
   ## This is a very expensive operation
@@ -532,6 +538,7 @@ func merge*(
   ## There shouldn't be a use-case where ``ctx_from`` is reused afterwards
   ## hence it is marked as sink.
   return BLST_SUCCESS == ctx_into.c.blst_pairing_merge(ctx_from.c)
+{.pop.}
 
 func finalVerify*(ctx: var ContextMultiAggregateVerify): bool {.inline.} =
   ## Verify a whole batch of (PublicKey, message, Signature) triplets.

--- a/blscurve/blst/blst_min_pubkey_sig_core.nim
+++ b/blscurve/blst/blst_min_pubkey_sig_core.nim
@@ -520,7 +520,7 @@ func update*[T: char|byte](
       ctx.secureBlinding.bls_sha256_digest(ctx.secureBlinding)
     blindingScalar.blst_scalar_from_lendian(blindingAsArray[])
 
-  result = BLST_SUCCESS == ctx.c.blst_pairing_chk_n_mul_n_aggr_pk_in_g1(
+  BLST_SUCCESS == ctx.c.blst_pairing_chk_n_mul_n_aggr_pk_in_g1(
     publicKey.point.unsafeAddr,
     pk_grpchk = false, # Already grouped checked
     signature.point.unsafeAddr,

--- a/blscurve/blst/sha256_abi.nim
+++ b/blscurve/blst/sha256_abi.nim
@@ -35,6 +35,13 @@ proc blst_sha256_final(
        ctx: var BLST_SHA256_CTX
      ){.importc: "sha256_final", header: headerPath, cdecl.}
 
+## No Nim checks in OpenMP multithreading land, failure allocates an exception.
+## No stacktraces either.
+## For debugging a parallel OpenMP region, put "attachGC"
+## as the first statement after "omp_parallel"
+## Then you can echo strings and reenable stacktraces
+{.push stacktrace:off, checks: off.}
+
 proc init*(ctx: var BLST_SHA256_CTX) =
   blst_sha256_init(ctx)
 

--- a/blscurve/blst/sha256_abi.nim
+++ b/blscurve/blst/sha256_abi.nim
@@ -12,6 +12,13 @@ type
     header: headerPath,
     incompleteStruct, byref.} = object
 
+## No Nim checks in OpenMP multithreading land, failure allocates an exception.
+## No stacktraces either.
+## For debugging a parallel OpenMP region, put "attachGC"
+## as the first statement after "omp_parallel"
+## Then you can echo strings and reenable stacktraces
+{.push stacktrace:off, checks: off.}
+
 # We need to make sure that calls go through this file
 # and don't directly use the underlying "sha256_init"
 # otherwise we can't enforce that "vect.h" is imported
@@ -35,13 +42,6 @@ proc blst_sha256_final(
        ctx: var BLST_SHA256_CTX
      ){.importc: "sha256_final", header: headerPath, cdecl.}
 
-## No Nim checks in OpenMP multithreading land, failure allocates an exception.
-## No stacktraces either.
-## For debugging a parallel OpenMP region, put "attachGC"
-## as the first statement after "omp_parallel"
-## Then you can echo strings and reenable stacktraces
-{.push stacktrace:off, checks: off.}
-
 proc init*(ctx: var BLST_SHA256_CTX) =
   blst_sha256_init(ctx)
 
@@ -60,4 +60,17 @@ proc bls_sha256_digest*[T: byte|char](
   var ctx{.noInit.}: BLST_SHA256_CTX
   ctx.blst_sha256_init()
   ctx.blst_sha256_update(input)
+  digest.blst_sha256_final(ctx)
+
+proc bls_sha256_digest*[T, U: byte|char](
+       digest: var array[32, byte],
+       input: openarray[T],
+       sepTag: openArray[U]
+     ) =
+  # Workaround linker issue when using init/update/update/finalize
+  # in ContextMultiAggregateVerify.init()
+  var ctx{.noInit.}: BLST_SHA256_CTX
+  ctx.blst_sha256_init()
+  ctx.blst_sha256_update(input)
+  ctx.blst_sha256_update(sepTag)
   digest.blst_sha256_final(ctx)

--- a/blscurve/eth2_keygen/hkdf_mod_r_blst.nim
+++ b/blscurve/eth2_keygen/hkdf_mod_r_blst.nim
@@ -182,6 +182,9 @@ func keyGen*(ikm: openarray[byte], publicKey: var PublicKey, secretKey: var Secr
   #  6. PK = point_to_pubkey(xP)
   #  7. return (PK, SK)
 
+  if ikm.len < 32:
+    return false
+
   # The cast is a workaround for private field access
   cast[ptr blst_scalar](secretKey.addr)[].blst_keygen(ikm, info = "")
   result = publicKey.publicFromSecret(secretKey)

--- a/blscurve/openmp.nim
+++ b/blscurve/openmp.nim
@@ -135,10 +135,10 @@ template omp_chunks*(
   # a base_chunk_size of 40/12 = 3 so work on the first 11 threads
   # will be 3 * 11 = 33, and the remainder 7 on the last thread.
   let
-    nb_chunks = omp_get_num_threads()
+    nb_chunks = omp_get_num_threads().uint32
     base_chunk_size = omp_size div nb_chunks
     remainder = omp_size mod nb_chunks
-    thread_id = omp_get_thread_num()
+    thread_id = omp_get_thread_num().uint32
 
   # Instead of dividing 40 work items on 12 cores into:
   # 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 7 = 3*11 + 7 = 40

--- a/blscurve/openmp.nim
+++ b/blscurve/openmp.nim
@@ -1,0 +1,211 @@
+# Nim-BLST
+# Copyright (c) 2020 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+#
+# Laser
+# Copyright (c) 2018 Mamy André-Ratsimbazafy
+# Distributed under the Apache v2 License (license terms are at http://www.apache.org/licenses/LICENSE-2.0).
+# This file may not be copied, modified, or distributed except according to those terms.
+
+when defined(openmp):
+  {.passC: "-fopenmp".}
+  {.passL: "-fopenmp".}
+
+  {.pragma: omp, header:"omp.h".}
+
+  proc omp_set_num_threads*(x: cint) {.omp.}
+  proc omp_get_num_threads*(): cint {.omp.}
+  proc omp_get_max_threads*(): cint {.omp.} # This takes hyperthreading into account
+  proc omp_get_thread_num*(): cint {.omp.}
+  proc omp_set_nested*(x: cint) {.omp.}
+  proc omp_get_nested*(): cint {.omp.}
+
+else:
+  template omp_set_num_threads*(x: cint) = discard
+  template omp_get_num_threads*(): cint = 1
+  template omp_get_max_threads*(): cint = 1
+  template omp_get_thread_num*(): cint = 0
+  template omp_set_nested*(x: cint) = discard
+  template omp_get_nested*(): cint = cint 0
+
+# ################################################################
+
+template attachGC*(): untyped =
+  ## If you are allocating reference types, sequences or strings
+  ## in a parallel section, you need to attach and detach
+  ## a GC for each thread. Those should be thread-local temporaries.
+  ##
+  ## This attaches the GC.
+  ##
+  ## Note: this creates too strange error messages
+  ## when --threads is not on: https://github.com/nim-lang/Nim/issues/9489
+  if(omp_get_thread_num()!=0):
+    setupForeignThreadGc()
+
+template detachGC*(): untyped =
+  ## If you are allocating reference types, sequences or strings
+  ## in a parallel section, you need to attach and detach
+  ## a GC for each thread. Those should be thread-local temporaries.
+  ##
+  ## This detaches the GC.
+  ##
+  ## Note: this creates too strange error messages
+  ## when --threads is not on: https://github.com/nim-lang/Nim/issues/9489
+  if(omp_get_thread_num()!=0):
+    teardownForeignThreadGc()
+
+template omp_parallel*(body: untyped): untyped =
+  ## Starts an openMP parallel section
+  ##
+  ## Don't forget to use attachGC and detachGC if you are allocating
+  ## sequences, strings, or reference types.
+  ## Those should be thread-local temporaries.
+  {.emit: "#pragma omp parallel".}
+  block: body
+
+template omp_parallel_if*(condition: bool, body: untyped) =
+  let predicate = condition # Make symbol valid and ensure it's a lvalue
+  {.emit: ["#pragma omp parallel if (",predicate,")"].}
+  block: body
+
+template omp_for*(
+    index: untyped,
+    length: Natural,
+    annotation: static string,
+    body: untyped
+  ) =
+  ## OpenMP for loop (not parallel)
+  ##
+  ## This must be used in an `omp_parallel` block
+  ## for parallelization.
+  ##
+  ## Inputs:
+  ##   - `index`, the iteration index, similar to
+  ##     for `index` in 0 ..< length:
+  ##       doSomething(`index`)
+  ##   - `length`, the number of elements to iterate on
+  ##
+  ## Defaults to OpenMP defaults
+  ## - nowait: off
+  ## - simd: off
+  ## - schedule: static
+  ## Change "annotation" otherwise
+  const omp_annotation = "for " & annotation
+  for `index`{.inject.} in `||`(0, length-1, omp_annotation):
+    block: body
+
+template omp_chunks*(
+    omp_size: Natural, #{lvalue} # TODO parameter constraint, pending https://github.com/nim-lang/Nim/issues/9620
+    chunk_offset, chunk_size: untyped,
+    body: untyped): untyped =
+  ## Internal proc
+  ## This is is the chunk part of omp_parallel_chunk
+  ## omp_size should be a lvalue (assigned value) and not
+  ## the result of a routine otherwise routine and its side-effect will be called multiple times
+  ##
+  ## If the omp_size to split in equal chunks of work
+  ## is less than the number of threads, the extra threads
+  ## will execute any code.
+  ## In particular indexing with a thread ID
+  ## into a sequence of size min(omp_size, omp_get_num_threads())
+  ## is safe.
+
+  # The following simple chunking scheme can lead to severe load imbalance
+  #
+  # `chunk_offset`{.inject.} = chunk_size * thread_id
+  # `chunk_size`{.inject.} =  if thread_id < nb_chunks - 1: chunk_size
+  #                           else: omp_size - chunk_offset
+  #
+  # For example dividing 40 items on 12 threads will lead to
+  # a base_chunk_size of 40/12 = 3 so work on the first 11 threads
+  # will be 3 * 11 = 33, and the remainder 7 on the last thread.
+  let
+    nb_chunks = omp_get_num_threads()
+    base_chunk_size = omp_size div nb_chunks
+    remainder = omp_size mod nb_chunks
+    thread_id = omp_get_thread_num()
+
+  # Instead of dividing 40 work items on 12 cores into:
+  # 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 7 = 3*11 + 7 = 40
+  # the following scheme will divide into
+  # 4, 4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3 = 4*4 + 3*8 = 40
+  #
+  # This is compliant with OpenMP spec (page 60)
+  # http://www.openmp.org/mp-documents/openmp-4.5.pdf
+  # "When no chunk_size is specified, the iteration space is divided into chunks
+  # that are approximately equal in size, and at most one chunk is distributed to
+  # each thread. The size of the chunks is unspecified in this case."
+  # ---> chunks are the same ±1
+
+  var `chunk_offset`{.inject.}, `chunk_size`{.inject.}: Natural
+  if thread_id < remainder:
+    chunk_offset = (base_chunk_size + 1) * thread_id
+    chunk_size = base_chunk_size + 1
+  else:
+    chunk_offset = base_chunk_size * thread_id + remainder
+    chunk_size = base_chunk_size
+
+  # If the number of threads is greater than the omp_size to split
+  # we have
+  #   base_chunk_size = 0
+  #   remainder = omp_size
+  # hence threadID < omp_size will receive one chunk each
+  # and we need to skip processing for the extra threads
+
+  block:
+    if thread_id < omp_size:
+      body
+
+template omp_critical*(body: untyped): untyped =
+  {.emit: "#pragma omp critical".}
+  block: body
+
+template omp_master*(body: untyped): untyped =
+  {.emit: "#pragma omp master".}
+  block: body
+
+template omp_single*(body: untyped): untyped =
+  {.emit: "#pragma omp single".}
+  block: body
+
+template omp_single_nowait*(body: untyped): untyped =
+  {.emit: "#pragma omp single nowait".}
+  block: body
+
+template omp_barrier*(): untyped =
+  {.emit: "#pragma omp barrier".}
+
+template omp_task*(annotation: static string, body: untyped): untyped =
+  {.emit: "#pragma omp task " & annotation.}
+  block: body
+
+template omp_taskwait*(): untyped =
+  {.emit: "#pragma omp taskwait".}
+
+template omp_taskloop*(
+    index: untyped,
+    length: Natural,
+    annotation: static string,
+    body: untyped
+  ) =
+  ## OpenMP taskloop
+  const omp_annotation = "taskloop " & annotation
+  for `index`{.inject.} in `||`(0, length-1, omp_annotation):
+    block: body
+
+import macros
+macro omp_flush*(variables: varargs[untyped]): untyped =
+  var listvars = "("
+  for i, variable in variables:
+    if i == 0:
+      listvars.add "`" & $variable & "`"
+    else:
+      listvars.add ",`" & $variable & "`"
+  listvars.add ')'
+  result = quote do:
+    {.emit: "#pragma omp flush " & `listvars`.}

--- a/blscurve/openmp.nim
+++ b/blscurve/openmp.nim
@@ -20,6 +20,11 @@ when defined(openmp):
 
   proc omp_set_num_threads*(x: cint) {.omp.}
   proc omp_get_num_threads*(): cint {.omp.}
+    ## Returns the number of threads assigned to this region
+    ##
+    ## Warning, this will always return 1 in a non-parallel region
+    ## use `omp_get_max_threads` to get the number of threads
+    ## available in a serial portion of the code.
   proc omp_get_max_threads*(): cint {.omp.} # This takes hyperthreading into account
   proc omp_get_thread_num*(): cint {.omp.}
   proc omp_set_nested*(x: cint) {.omp.}
@@ -28,6 +33,11 @@ when defined(openmp):
 else:
   template omp_set_num_threads*(x: cint) = discard
   template omp_get_num_threads*(): cint = 1
+    ## Returns the number of threads assigned to this region
+    ##
+    ## Warning, this will always return 1 in a non-parallel region
+    ## use `omp_get_max_threads` to get the number of threads
+    ## available in a serial portion of the code.
   template omp_get_max_threads*(): cint = 1
   template omp_get_thread_num*(): cint = 0
   template omp_set_nested*(x: cint) = discard

--- a/tests/t_batch_verifier.nim
+++ b/tests/t_batch_verifier.nim
@@ -69,14 +69,14 @@ suite "Batch verification " & omp_status():
     let (pubkey, seckey) = keyGen(123)
     let sig = seckey.sign(msg)
 
-    var batcher = init(BatchedBLSVerifier[32])
+    var batcher = init(BatchedBLSVerifier)
 
     check:
       batcher.incl(pubkey, msg, sig)
       batcher.batchVerify(fakeRandomBytes)
 
   wrappedTest "Verify 2 (pubkey, message, signature) triplets":
-    var batcher = init(BatchedBLSVerifier[32])
+    var batcher = init(BatchedBLSVerifier)
     batcher.inclExample(1, "msg1")
     batcher.inclExample(2, "msg2")
 
@@ -84,7 +84,7 @@ suite "Batch verification " & omp_status():
       batcher.batchVerify(fakeRandomBytes)
 
   wrappedTest "Verify 2^4 - 1 = 15 (pubkey, message, signature) triplets":
-    var batcher = init(BatchedBLSVerifier[32])
+    var batcher = init(BatchedBLSVerifier)
 
     for i in 0 ..< 15:
       batcher.inclExample(i, "msg" & $i)
@@ -93,7 +93,7 @@ suite "Batch verification " & omp_status():
       batcher.batchVerify(fakeRandomBytes)
 
   wrappedTest "Verify 2^4 = 16 (pubkey, message, signature) triplets":
-    var batcher = init(BatchedBLSVerifier[32])
+    var batcher = init(BatchedBLSVerifier)
 
     for i in 0 ..< 16:
       batcher.inclExample(i, "msg" & $i)
@@ -102,7 +102,7 @@ suite "Batch verification " & omp_status():
       batcher.batchVerify(fakeRandomBytes)
 
   wrappedTest "Verify 2^4 + 1 = 17 (pubkey, message, signature) triplets":
-    var batcher = init(BatchedBLSVerifier[32])
+    var batcher = init(BatchedBLSVerifier)
 
     for i in 0 ..< 17:
       batcher.inclExample(i, "msg" & $i)
@@ -118,7 +118,7 @@ suite "Batch verification " & omp_status():
 
     let (pubkey2, seckey2) = keyGen(2)
 
-    var batcher = init(BatchedBLSVerifier[32])
+    var batcher = init(BatchedBLSVerifier)
 
     check:
       batcher.incl(pubkey1, msg1, sig1)

--- a/tests/t_batch_verifier.nim
+++ b/tests/t_batch_verifier.nim
@@ -1,0 +1,126 @@
+# Nim-BLSCurve
+# Copyright (c) 2018-Present Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  # Standard library
+  unittest,
+  # internal
+  ../blscurve/openmp,
+  # Public API
+  ../blscurve
+
+# Tests for batch verification
+# Compile with -d:openmp for parallel tests
+proc omp_status(): string =
+  when defined(openmp):
+    "[Using OpenMP with " & $omp_get_max_threads() & " threads]"
+  else:
+    "[Serial]"
+
+template wrappedTest(desc: string, body: untyped): untyped =
+  ## Wrap test in a proc to avoid having globals everywhere
+  ## ballooning the test BSS space usage
+  ## properly test destructors/GC/try-finally, ...
+  ## aliasing
+  ## and optimizations (that don't apply to globals)
+  test desc:
+    proc wTest() =
+      body
+
+    wTest()
+
+proc keyGen(seed: uint64): tuple[pubkey: PublicKey, seckey: SecretKey] =
+  var ikm: array[32, byte]
+  ikm[0 ..< 8] = cast[array[8, byte]](seed)
+  let ok = ikm.keyGen(result.pubkey, result.seckey)
+  doAssert ok
+
+proc hash[T: byte|char](message: openarray[T]): array[32, byte] {.noInit.}=
+  result.bls_sha256_digest(message)
+
+proc inclExample(batcher: var BatchedBLSVerifier, seed: int, message: string) =
+  let (pubkey, seckey) = keyGen(seed.uint64)
+  let hashed = hash(message)
+  let sig = seckey.sign(hashed)
+  doAssert batcher.incl(pubkey, hashed, sig)
+
+# Test strategy
+# As we use a tree algorithm we want to test
+# - a single signature set
+# - a signature set of size 2^n-1
+# - a signature set of size 2^n
+# - a signature set of size 2^n+1
+# for boundary conditions
+# we also want to test forged signature sets
+# that would pass grouped verification
+# https://ethresear.ch/t/fast-verification-of-multiple-bls-signatures/5407/16
+
+let fakeRandomBytes = hash"Mr F was here"
+
+suite "Batch verification " & omp_status():
+  wrappedTest "Verify a single (pubkey, message, signature) triplet":
+    let msg = hash"message"
+    let (pubkey, seckey) = keyGen(123)
+    let sig = seckey.sign(msg)
+
+    var batcher = init(BatchedBLSVerifier[32])
+
+    check:
+      batcher.incl(pubkey, msg, sig)
+      batcher.batchVerify(fakeRandomBytes)
+
+  wrappedTest "Verify 2 (pubkey, message, signature) triplets":
+    var batcher = init(BatchedBLSVerifier[32])
+    batcher.inclExample(1, "msg1")
+    batcher.inclExample(2, "msg2")
+
+    check:
+      batcher.batchVerify(fakeRandomBytes)
+
+  wrappedTest "Verify 2^4 - 1 = 15 (pubkey, message, signature) triplets":
+    var batcher = init(BatchedBLSVerifier[32])
+
+    for i in 0 ..< 15:
+      batcher.inclExample(i, "msg" & $i)
+
+    check:
+      batcher.batchVerify(fakeRandomBytes)
+
+  wrappedTest "Verify 2^4 = 16 (pubkey, message, signature) triplets":
+    var batcher = init(BatchedBLSVerifier[32])
+
+    for i in 0 ..< 16:
+      batcher.inclExample(i, "msg" & $i)
+
+    check:
+      batcher.batchVerify(fakeRandomBytes)
+
+  wrappedTest "Verify 2^4 + 1 = 17 (pubkey, message, signature) triplets":
+    var batcher = init(BatchedBLSVerifier[32])
+
+    for i in 0 ..< 17:
+      batcher.inclExample(i, "msg" & $i)
+
+    check:
+      batcher.batchVerify(fakeRandomBytes)
+
+  wrappedTest "Wrong signature":
+    let msg1 = hash"msg1"
+    let msg2 = hash"msg2"
+    let (pubkey1, seckey1) = keyGen(1)
+    let sig1 = seckey1.sign(msg1)
+
+    let (pubkey2, seckey2) = keyGen(2)
+
+    var batcher = init(BatchedBLSVerifier[32])
+
+    check:
+      batcher.incl(pubkey1, msg1, sig1)
+      batcher.incl(pubkey2, msg2, sig1) # <--- wrong signature
+      not batcher.batchVerify(fakeRandomBytes)


### PR DESCRIPTION
This adds batched multi-signature verification to the library.
Both with serial or parallel backend with OpenMP.
The algorithm chosen is recursive divide-and-conquer instead of the usual parallel for loop,
this makes it easily portable to any threadpool that supports task spawning.

### Disambiguations
Unfortunately it is very easy to get confused with BLS signatures, signature aggregation and multi signature.

#### BLS signature level 1
We have a triplet (pubkey, message, signature) to verify.
This is the base case `verify` https://github.com/status-im/nim-blscurve/blob/b0a1d149e97142649bd99c4acebcf551b7b05dda/blscurve/bls_sig_min_pubkey.nim#L108-L114

#### BLS signature level 2
We have N public keys verifying the same message (attesting for a block for example)
This is `fastAggregateVerify`. https://github.com/status-im/nim-blscurve/blob/b0a1d149e97142649bd99c4acebcf551b7b05dda/blscurve/bls_sig_min_pubkey.nim#L230-L253

As shown in benchmark there is no use in parallelizing this case as by exploiting pairings curve properties can accelerate verification of **an aggregate signature against 128 public keys only take an extra 5.6%**
![image](https://user-images.githubusercontent.com/22738317/101365746-73970080-38a4-11eb-93df-1381b6381e63.png)

#### BLS signature level 3
We have N public keys verifying N messages which could be:
 - block proposals signatures
 - randao reveal signatures
 - proposer slashings signatures
 - attester slashings signatures
 - attestations signatures (needs level 2 as well)
 - validator exits signatures

not counting deposits signatures which may be invalid.
Furthermore we can apply that to B blocks to collect N*B signature sets.

This is the `aggregate(var Signature, Signature)` procedures and `aggregateVerify` procedures:
https://github.com/status-im/nim-blscurve/blob/b0a1d149e97142649bd99c4acebcf551b7b05dda/blscurve/blst/blst_min_pubkey_sig_core.nim#L141-L186
https://github.com/status-im/nim-blscurve/blob/b0a1d149e97142649bd99c4acebcf551b7b05dda/blscurve/bls_sig_min_pubkey.nim#L153-L156
https://github.com/status-im/nim-blscurve/blob/b0a1d149e97142649bd99c4acebcf551b7b05dda/blscurve/bls_sig_min_pubkey.nim#L177-L179

Those appear in the spec https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#bls-signatures but are never used hence as we kept almost literally to the spec we didn't use them.

The estimated perf improvement on a single block verification for the serial and parallel implementation are in the code at
https://github.com/status-im/nim-blscurve/blob/b0a1d149e97142649bd99c4acebcf551b7b05dda/blscurve/blst/blst_min_pubkey_sig_core.nim#L401-L422
In summary by batching even on a single processor we have 2x faster single block verification.
If batching 10 blocks, instead of a naive cost of 1000, the cost becomes
`20*10 (blinding 64-bit) + 50 (Miller loop) + 50 (final exp) = 300` for a 3.33x acceleration factor

**The performance improvements are superlinear and increase with both the number of processors and the workload.**

### Batching signatures
The existing aggregateVerify functions are impractical as we need to save state for batching.
Instead we can pass a collector object to collect all (publicKey(s), message, signature) triplets (called Signature Sets here, as in Lighthouse and Prysm) in a block and then run verification once everything as been collected.

We actually do not core which verification fails, if any fails we need to drop the block anyway (unless some precise attacker accountability on invalid signatures is introduced).

This PR implements such collector object `BatchBLSVerifier` with a serial and parallel backend using OpenMP.

#### Parallel implementation

Contrary to BLST example which uses a simple parallel for loop followed by serial for loop for merging partial pairings, we use a recursive divide-and-conquer strategy, this doesn't change the cost of computing the partial pairings but significantly improve merging them (logarithmic vs linear) and merging partial pairings is a costly operation.

Reference merging code: https://github.com/supranational/blst/blob/7cda6fa09bfa9d789bd30b31dc1ae91656ee2f88/bindings/rust/src/lib.rs#L756-L759

As an example on Pyrmont 2 weeks old, 100000 blocks, a linear merge on my machine would have an estimated cost of 0.3s per 20 blocks which lead to 100000/20 * 0.3 = 1500s spent, 20 weeks would be 15000s so 4.1 hours.

With a divide-and-conquer approach on a 6 core CPU as in the code example we save half that https://github.com/status-im/nim-blscurve/blob/b0a1d149e97142649bd99c4acebcf551b7b05dda/blscurve/bls_batch_verifier.nim#L242-L245

https://github.com/status-im/nim-blscurve/blob/b0a1d149e97142649bd99c4acebcf551b7b05dda/blscurve/bls_batch_verifier.nim#L204-L262

### Nimbus unknowns

1. A RFC will be submitted to discuss the following details
- Architecture change in Nimbus `process_block` to allow batching of all signatures within a block. This only affects consensus.
- Changing sync and/or introducing `batch_process_blocks` to batch all signatures of many blocks.

2. We will likely need 1 or 2 nodes in our fleet to test this PR on Pyrmont and the consequent Nimbus refactoring that will likely be complex to rebase and will live in a branch for a long time.
