### PR TITLE
Fix compilation error because of missing vendor directory

### DIFF
--- a/blscurve.nimble
+++ b/blscurve.nimble
@@ -6,6 +6,9 @@ author        = "Status Research & Development GmbH"
 description   = "BLS381-12 Curve implementation"
 license       = "Apache License 2.0"
 
+installDirs = @["blscurve", "vendor"]
+installFiles = @["blscurve.nim"]
+
 ### Dependencies
 requires "nim >= 1.0.4",
          "nimcrypto",


### PR DESCRIPTION
When nimble is used to add blscurve to a nim project, the following error appears:

```
gcc: error: ../../vendor/blst/build/assembly.S: No such file or directory
gcc: fatal error: no input files
compilation terminated.
gcc: error: ../../vendor/blst/src/server.c: No such file or directory
gcc: fatal error: no input files
compilation terminated.
```

This PR adds the 'vendor' directory to the list of directories that should be installed, fixing the issue.