### PR TITLE
Update eth2_vectors.nim

### DIFF
--- a/tests/eth2_vectors.nim
+++ b/tests/eth2_vectors.nim
@@ -187,14 +187,15 @@ testGen(sign, test):
 
   doAssert privkey.ok == expectedSig.ok
   if not privkey.ok or not expectedSig.ok:
-    return
+    echo ("")
+  else:
 
-  let libSig = privKey.val.sign(message.val)
+    let libSig = privKey.val.sign(message.val)
 
-  doAssert libSig == expectedSig.val, block:
-    "\nSignature differs from expected \n" &
-    "   computed: " & libSig.toHex() & "\n" &
-    "   expected: " & expectedSig.val.toHex()
+    doAssert libSig == expectedSig.val, block:
+      "\nSignature differs from expected \n" &
+      "   computed: " & libSig.toHex() & "\n" &
+      "   expected: " & expectedSig.val.toHex()
 
 testGen(verify, test):
   let
@@ -206,25 +207,26 @@ testGen(verify, test):
   if not pubkey.ok:
     # Infinity pubkey and infinity signature
     doAssert not expected.val
-    return
+  
+  else:
 
-  let libValid = pubKey.val.verify(message.val, signature.val)
-
-  doAssert libValid == expected.val, block:
-    "\nVerification differs from expected \n" &
-    "   computed: " & $libValid & "\n" &
-    "   expected: " & $expected.val
-
-  withProof(pubKey.val):
-    let libValid = pubKey.val.verify(proof, message.val, signature.val)
+    let libValid = pubKey.val.verify(message.val, signature.val)
 
     doAssert libValid == expected.val, block:
-      "\nVerification with proof-of-possession differs from expected \n" &
+      "\nVerification differs from expected \n" &
       "   computed: " & $libValid & "\n" &
       "   expected: " & $expected.val
 
-    doAssert not pubKey.val.verify(wrongProof, message.val, signature.val), block:
-      "\nVerification with wrong proof-of-possession succeeded"
+    withProof(pubKey.val):
+      let libValid = pubKey.val.verify(proof, message.val, signature.val)
+
+      doAssert libValid == expected.val, block:
+        "\nVerification with proof-of-possession differs from expected \n" &
+        "   computed: " & $libValid & "\n" &
+        "   expected: " & $expected.val
+
+      doAssert not pubKey.val.verify(wrongProof, message.val, signature.val), block:
+        "\nVerification with wrong proof-of-possession succeeded"
 
 testGen(aggregate, test):
   let sigs = seq[Signature].getFrom(test, Input)
@@ -235,12 +237,13 @@ testGen(aggregate, test):
   if not ok:
     doAssert not expectedAgg.ok
     doAssert sigs.val.len == 0
-    return
 
-  doAssert libAggSig == expectedAgg.val, block:
-    "\nSignature aggregation differs from expected \n" &
-    "   computed: " & libAggSig.toHex() & "\n" &
-    "   expected: " & expectedAgg.val.toHex()
+  else:
+
+    doAssert libAggSig == expectedAgg.val, block:
+      "\nSignature aggregation differs from expected \n" &
+      "   computed: " & libAggSig.toHex() & "\n" &
+      "   expected: " & expectedAgg.val.toHex()
 
 testGen(fast_aggregate_verify, test):
   let
@@ -252,25 +255,26 @@ testGen(fast_aggregate_verify, test):
   if not pubkeys.ok:
     # Infinity pubkey in the mix
     doAssert not expected.val
-    return
 
-  let libValid = pubKeys.val.fastAggregateVerify(message.val, signature.val)
+  else:
 
-  doAssert libValid == expected.val, block:
-    "\nFast Aggregate Verification differs from expected \n" &
-    "   computed: " & $libValid & "\n" &
-    "   expected: " & $expected.val
-    
-  withProofs(pubKeys.val):
-    let libValid = pubKeys.val.fastAggregateVerify(proofs, message.val, signature.val)
+    let libValid = pubKeys.val.fastAggregateVerify(message.val, signature.val)
 
     doAssert libValid == expected.val, block:
-      "\nFast Aggregate Verification with proof-of-possession differs from expected \n" &
+      "\nFast Aggregate Verification differs from expected \n" &
       "   computed: " & $libValid & "\n" &
       "   expected: " & $expected.val
+      
+    withProofs(pubKeys.val):
+      let libValid = pubKeys.val.fastAggregateVerify(proofs, message.val, signature.val)
 
-    doAssert not pubKeys.val.fastAggregateVerify(wrongProofs, message.val, signature.val), block:
-      "\nFast Aggregate Verification with wrong proof-of-possession succeeded"
+      doAssert libValid == expected.val, block:
+        "\nFast Aggregate Verification with proof-of-possession differs from expected \n" &
+        "   computed: " & $libValid & "\n" &
+        "   expected: " & $expected.val
+
+      doAssert not pubKeys.val.fastAggregateVerify(wrongProofs, message.val, signature.val), block:
+        "\nFast Aggregate Verification with wrong proof-of-possession succeeded"
 
 testGen(aggregate_verify, test):
   let
@@ -288,28 +292,29 @@ testGen(aggregate_verify, test):
     # Infinity pubkey in the mix
     doAssert not pubkey_msg_pairs.ok
     doAssert not expected.val
-    return
 
-  doAssert libAoSValid == expected.val, block:
-    "\nAggregate Verification differs from expected \n" &
-    "   computed: " & $libAoSValid & "\n" &
-    "   expected: " & $expected.val
+  else:
 
-  doAssert libSoAValid == expected.val, block:
-    "\nAggregate Verification differs from expected \n" &
-    "   computed: " & $libSoAValid & "\n" &
-    "   expected: " & $expected.val
-
-  withProofs(pubkeys.val):
-    let libValid = pubkeys.val.aggregateVerify(proofs, msgs.val, signature.val)
-
-    doAssert libValid == expected.val, block:
-      "\nAggregate Verification with proof-of-possession differs from expected \n" &
-      "   computed: " & $libValid & "\n" &
+    doAssert libAoSValid == expected.val, block:
+      "\nAggregate Verification differs from expected \n" &
+      "   computed: " & $libAoSValid & "\n" &
       "   expected: " & $expected.val
 
-    doAssert not pubkeys.val.aggregateVerify(wrongProofs, msgs.val, signature.val), block:
-      "\nAggregate Verification with wrong proof-of-possession succeeded"
+    doAssert libSoAValid == expected.val, block:
+      "\nAggregate Verification differs from expected \n" &
+      "   computed: " & $libSoAValid & "\n" &
+      "   expected: " & $expected.val
+
+    withProofs(pubkeys.val):
+      let libValid = pubkeys.val.aggregateVerify(proofs, msgs.val, signature.val)
+
+      doAssert libValid == expected.val, block:
+        "\nAggregate Verification with proof-of-possession differs from expected \n" &
+        "   computed: " & $libValid & "\n" &
+        "   expected: " & $expected.val
+
+      doAssert not pubkeys.val.aggregateVerify(wrongProofs, msgs.val, signature.val), block:
+        "\nAggregate Verification with wrong proof-of-possession succeeded"
 
 suite "ETH 2.0 " & BLS_ETH2_SPEC & " test vectors - " & $BLS_BACKEND:
   test "[" & BLS_ETH2_SPEC & "] sign(SecretKey, message) -> Signature":


### PR DESCRIPTION
It seems that the `return` used in `eth2_vectors.nim` is causing many spec tests to be skipped.

using `nimble test`

```

[Suite] ETH 2.0 v1.0.0 test vectors - BLST
       sign test: small/sign_case_7055381f640f2c1d/data.yaml
       sign test: small/sign_case_c82df61aa3ee60fb/data.yaml
       sign test: small/sign_case_8cd3d4d0d9a5b265/data.yaml
       sign test: small/sign_case_11b8c7cad5238946/data.yaml
       sign test: small/sign_case_d0e28d7e76eb6e9c/data.yaml
       sign test: small/sign_case_zero_privkey/data.yaml
  [OK] [v1.0.0] sign(SecretKey, message) -> Signature
       verify test: small/verify_tampered_signature_case_2ea479adf8c40300/data.yaml
       verify test: small/verify_wrong_pubkey_case_6b3b17f6962a490c/data.yaml
       verify test: small/verify_valid_case_3208262581c8fc09/data.yaml
       verify test: small/verify_wrong_pubkey_case_e8a50c445c855360/data.yaml
       verify test: small/verify_wrong_pubkey_case_6eeb7c52dfd9baf0/data.yaml
       verify test: small/verify_wrong_pubkey_case_2f09d443ab8a3ac2/data.yaml
       verify test: small/verify_wrong_pubkey_case_8761a0b7e920c323/data.yaml
       verify test: small/verify_wrong_pubkey_case_d34885d766d5f705/data.yaml
       verify test: small/verify_infinity_pubkey_and_infinity_signature/data.yaml
  [OK] [v1.0.0] verify(PublicKey, message, Signature) -> bool
       aggregate test: small/aggregate_0x5656565656565656565656565656565656565656565656565656565656565656/data.yaml
       aggregate test: small/aggregate_na_signatures/data.yaml
       aggregate test: small/aggregate_0x0000000000000000000000000000000000000000000000000000000000000000/data.yaml
       aggregate test: small/aggregate_0xabababababababababababababababababababababababababababababababab/data.yaml
       aggregate test: small/aggregate_infinity_signature/data.yaml
  [OK] [v1.0.0] aggregate(openarray[Signature]) -> Signature
       fast_aggregate_verify test: small/fast_aggregate_verify_valid_3d7576f3c0e3570a/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_extra_pubkey_a698ea45b109f303/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_tampered_signature_3d7576f3c0e3570a/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_na_pubkeys_and_na_signature/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_extra_pubkey_5a38e6b4017fe4dd/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_valid_652ce62f09290811/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_tampered_signature_5e745ad0c6199a6c/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_tampered_signature_652ce62f09290811/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_extra_pubkey_4f079f946446fabf/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_na_pubkeys_and_infinity_signature/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_infinity_pubkey/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_valid_5e745ad0c6199a6c/data.yaml
  [OK] [v1.0.0] fastAggregateVerify(openarray[PublicKey], message, Signature) -> bool
       aggregate_verify test: small/aggregate_verify_na_pubkeys_and_na_signature/data.yaml
       aggregate_verify test: small/aggregate_verify_tampered_signature/data.yaml
       aggregate_verify test: small/aggregate_verify_na_pubkeys_and_infinity_signature/data.yaml
       aggregate_verify test: small/aggregate_verify_valid/data.yaml
       aggregate_verify test: small/aggregate_verify_infinity_pubkey/data.yaml
  [OK] [v1.0.0] AggregateVerify(openarray[PublicKey, message], Signature) -> bool
```

after the patch in this PR is applied all the test are executed

```
[Suite] ETH 2.0 v1.0.0 test vectors - BLST
       sign test: small/sign_case_7055381f640f2c1d/data.yaml
       sign test: small/sign_case_c82df61aa3ee60fb/data.yaml
       sign test: small/sign_case_8cd3d4d0d9a5b265/data.yaml
       sign test: small/sign_case_11b8c7cad5238946/data.yaml
       sign test: small/sign_case_d0e28d7e76eb6e9c/data.yaml
       sign test: small/sign_case_zero_privkey/data.yaml

       sign test: small/sign_case_37286e1a6d1f6eb3/data.yaml
       sign test: small/sign_case_84d45c9c7cca6b92/data.yaml
       sign test: small/sign_case_142f678a8d05fcd1/data.yaml
       sign test: small/sign_case_f2ae1097e7d0e18b/data.yaml
  [OK] [v1.0.0] sign(SecretKey, message) -> Signature
       verify test: small/verify_tampered_signature_case_2ea479adf8c40300/data.yaml
       verify test: small/verify_wrong_pubkey_case_6b3b17f6962a490c/data.yaml
       verify test: small/verify_valid_case_3208262581c8fc09/data.yaml
       verify test: small/verify_wrong_pubkey_case_e8a50c445c855360/data.yaml
       verify test: small/verify_wrong_pubkey_case_6eeb7c52dfd9baf0/data.yaml
       verify test: small/verify_wrong_pubkey_case_2f09d443ab8a3ac2/data.yaml
       verify test: small/verify_wrong_pubkey_case_8761a0b7e920c323/data.yaml
       verify test: small/verify_wrong_pubkey_case_d34885d766d5f705/data.yaml
       verify test: small/verify_infinity_pubkey_and_infinity_signature/data.yaml
       verify test: small/verify_tampered_signature_case_3208262581c8fc09/data.yaml
       verify test: small/verify_valid_case_2ea479adf8c40300/data.yaml
       verify test: small/verify_wrong_pubkey_case_195246ee3bd3b6ec/data.yaml
       verify test: small/verify_valid_case_195246ee3bd3b6ec/data.yaml
       verify test: small/verify_wrong_pubkey_case_2ea479adf8c40300/data.yaml
       verify test: small/verify_valid_case_8761a0b7e920c323/data.yaml
       verify test: small/verify_valid_case_2f09d443ab8a3ac2/data.yaml
       verify test: small/verify_valid_case_6eeb7c52dfd9baf0/data.yaml
       verify test: small/verify_tampered_signature_case_6b3b17f6962a490c/data.yaml
       verify test: small/verify_valid_case_d34885d766d5f705/data.yaml
       verify test: small/verify_tampered_signature_case_e8a50c445c855360/data.yaml
       verify test: small/verify_tampered_signature_case_6eeb7c52dfd9baf0/data.yaml
       verify test: small/verify_valid_case_6b3b17f6962a490c/data.yaml
       verify test: small/verify_tampered_signature_case_2f09d443ab8a3ac2/data.yaml
       verify test: small/verify_tampered_signature_case_8761a0b7e920c323/data.yaml
       verify test: small/verify_valid_case_e8a50c445c855360/data.yaml
       verify test: small/verify_tampered_signature_case_d34885d766d5f705/data.yaml
       verify test: small/verify_wrong_pubkey_case_3208262581c8fc09/data.yaml
       verify test: small/verify_tampered_signature_case_195246ee3bd3b6ec/data.yaml
  [OK] [v1.0.0] verify(PublicKey, message, Signature) -> bool
       aggregate test: small/aggregate_0x5656565656565656565656565656565656565656565656565656565656565656/data.yaml
       aggregate test: small/aggregate_na_signatures/data.yaml
       aggregate test: small/aggregate_0x0000000000000000000000000000000000000000000000000000000000000000/data.yaml
       aggregate test: small/aggregate_0xabababababababababababababababababababababababababababababababab/data.yaml
       aggregate test: small/aggregate_infinity_signature/data.yaml
  [OK] [v1.0.0] aggregate(openarray[Signature]) -> Signature
       fast_aggregate_verify test: small/fast_aggregate_verify_valid_3d7576f3c0e3570a/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_extra_pubkey_a698ea45b109f303/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_tampered_signature_3d7576f3c0e3570a/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_na_pubkeys_and_na_signature/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_extra_pubkey_5a38e6b4017fe4dd/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_valid_652ce62f09290811/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_tampered_signature_5e745ad0c6199a6c/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_tampered_signature_652ce62f09290811/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_extra_pubkey_4f079f946446fabf/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_na_pubkeys_and_infinity_signature/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_infinity_pubkey/data.yaml
       fast_aggregate_verify test: small/fast_aggregate_verify_valid_5e745ad0c6199a6c/data.yaml
  [OK] [v1.0.0] fastAggregateVerify(openarray[PublicKey], message, Signature) -> bool
       aggregate_verify test: small/aggregate_verify_na_pubkeys_and_na_signature/data.yaml
       aggregate_verify test: small/aggregate_verify_tampered_signature/data.yaml
       aggregate_verify test: small/aggregate_verify_na_pubkeys_and_infinity_signature/data.yaml
       aggregate_verify test: small/aggregate_verify_valid/data.yaml
       aggregate_verify test: small/aggregate_verify_infinity_pubkey/data.yaml
  [OK] [v1.0.0] AggregateVerify(openarray[PublicKey, message], Signature) -> bool
```
