### PR TITLE
BLST: allow disabling SSSE3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ This library uses:
 - [SupraNational BLST](https://github.com/supranational/blst) on x86-64 and ARM64
 - [MIRACL Core](https://github.com/miracl/core) on all other platforms.
 
+BLST uses SSSE3 by default, if supported on the host. To disable that, when building
+binaries destined for older CPUs, pass `-d:BLSTuseSSSE3=0` to the Nim compiler.
+
 ### Keeping track of upstream
 
 To keep track of upstream AMCL:
@@ -110,7 +113,7 @@ Licensed and distributed under either of
 * MIT license: [LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT
 * Apache License, Version 2.0, ([LICENSE-APACHEv2](LICENSE-APACHEv2) or http://www.apache.org/licenses/LICENSE-2.0)
 
-at your option. This file may not be copied, modified, or distributed except according to those terms.
+at your option. These files may not be copied, modified, or distributed except according to those terms.
 
 ### Dependencies
 

--- a/benchmarks/bls_signature.nim
+++ b/benchmarks/bls_signature.nim
@@ -59,8 +59,9 @@ proc benchDeserPubkeyKnownOnCurve*(iters: int) =
 
   var pk2{.noInit.}: PublicKey
 
-  bench("Pubkey deserialization (known on curve)", iters):
-    doAssert pk2.fromBytesKnownOnCurve(pk_comp)
+  when BLS_BACKEND == BLST:
+    bench("Pubkey deserialization (known on curve)", iters):
+      doAssert pk2.fromBytesKnownOnCurve(pk_comp)
 
 proc benchDeserSig*(iters: int) =
   const seckey = "00000000000000000000000000000000000000000000000000000000000003e8"
@@ -107,8 +108,9 @@ proc benchDeserSigKnownOnCurve*(iters: int) =
 
   var sig2{.noInit.}: Signature
 
-  bench("Signature deserialization (known on curve)", iters):
-    doAssert sig2.fromBytesKnownOnCurve(sig_comp)
+  when BLS_BACKEND == BLST:
+    bench("Signature deserialization (known on curve)", iters):
+      doAssert sig2.fromBytesKnownOnCurve(sig_comp)
 
 proc benchSign*(iters: int) =
   let msg = "Mr F was here"
@@ -232,14 +234,15 @@ when BLS_BACKEND == BLST:
 
 when isMainModule:
   benchDeserPubkey(1000)
-  benchDeserPubkeyKnownOnCurve(1000)
   benchDeserSig(1000)
-  benchDeserSigKnownOnCurve(1000)
   benchSign(1000)
   benchVerify(1000)
   benchFastAggregateVerify(numKeys = 128, iters = 10)
 
   when BLS_BACKEND == BLST:
+    benchDeserPubkeyKnownOnCurve(1000)
+    benchDeserSigKnownOnCurve(1000)
+
     var nthreads: int
     if existsEnv"TP_NUM_THREADS":
       nthreads = getEnv"TP_NUM_THREADS".parseInt()

--- a/blscurve/blst/blst_lowlevel.nim
+++ b/blscurve/blst/blst_lowlevel.nim
@@ -9,19 +9,6 @@
 
 import std/os
 
-when defined(gcc):
-  # * Using ftree-loop-vectorize will miscompile scalar multiplication
-  #   for example used to derive the public key in blst_sk_to_pk_in_g1
-  # * Using ftree-slp-vectorize miscompiles something when used
-  #   in nim-beacon-chain in Travis CI (TODO: test case)
-  # no-tree-vectorize removes both
-  {.passC: "-fno-tree-vectorize".}
-  #
-  # From https://github.com/supranational/blst/issues/22
-  # it seems like some "restrict" in the library still misscompile
-  # We can alternatively remove restrict (for the whole n)
-  # {.passC: "-Drestrict=".}
-
 {.compile: "../../vendor/blst/build/assembly.S".}
 {.compile: "../../vendor/blst/src/server.c".}
 

--- a/blscurve/blst/blst_min_pubkey_sig_core.nim
+++ b/blscurve/blst/blst_min_pubkey_sig_core.nim
@@ -125,9 +125,6 @@ include ./bls_sig_io
 
 func publicFromSecret*(pubkey: var PublicKey, seckey: SecretKey): bool =
   ## Generates a public key from a secret key
-  ## This requires some -O3 compiler optimizations to be off
-  ## as such {.passC: "-fno-tree-vectorize".}
-  ## is automatically added to the compiler flags in blst_lowlevel
   ##
   ## Returns:
   ## - false is secret key is invalid (SK == 0 or >= BLS12-381 curve order),


### PR DESCRIPTION
Also fix some CI benchmarks and no longer pass "-fno-tree-vectorize" to the C compiler.