### PR TITLE
Close remaining sec issues

### DIFF
--- a/blscurve/miracl/bls_sig_io.nim
+++ b/blscurve/miracl/bls_sig_io.nim
@@ -47,8 +47,8 @@ func fromBytes*[T: SecretKey|PublicKey|Signature|ProofOfPossession](
   ## Initialize a BLS signature scheme object from
   ## its raw bytes representation.
   ## Returns true on success and false otherwise
-  ## For secret key deserialization
-  ## A zero key is invalid
+  ## 
+  ## A zero public key is invalid
   when obj is SecretKey:
     result = obj.intVal.fromBytes(raw)
     if obj.intVal.isZilch():
@@ -64,6 +64,19 @@ func fromBytes*[T: SecretKey|PublicKey|Signature|ProofOfPossession](
         result = false
     if not subgroupCheck(obj.point):
       return false
+
+func fromBytesKnownOnCurve*[T: PublicKey|Signature|ProofOfPossession](
+       obj: var T,
+       raw: openarray[byte]
+      ): bool {.inline.} =
+  ## Initialize a BLS signature scheme object from
+  ## its raw bytes representation.
+  ## Returns true on success and false otherwise
+  ##
+  ## The point is known to be on curve:
+  ## - Public key are not checked for infinity points
+  ## - PublicKey, Signature, Proof of possessions are not subgroup checked
+  result = obj.point.fromBytes(raw)
 
 func toHex*(obj: SecretKey|PublicKey|Signature|ProofOfPossession): string {.inline.} =
   ## Return the hex representation of a BLS signature scheme object

--- a/tests/serialization.nim
+++ b/tests/serialization.nim
@@ -28,6 +28,20 @@ when BLS_BACKEND == BLST:
 
   test_zero_sig()
 
+# [Security] Harden against seemingly valid BLS signature
+# https://github.com/status-im/nimbus-eth2/issues/555
+
+echo "\nInvalid infinity point encoding"
+echo "----------------------------------\n"
+
+proc test_invalid_infinity() =
+  let sigbytes = @[byte 217, 149, 255, 97, 73, 133, 236, 43, 248, 34, 30, 10, 15, 45, 82, 72, 243, 179, 53, 17, 27, 17, 248, 180, 7, 92, 200, 153, 11, 3, 111, 137, 124, 171, 29, 218, 191, 246, 148, 57, 160, 50, 232, 129, 81, 90, 72, 161, 110, 138, 243, 116, 0, 88, 125, 180, 67, 153, 194, 181, 117, 152, 166, 147, 13, 77, 15, 91, 33, 50, 140, 199, 150, 10, 15, 10, 209, 165, 38, 57, 56, 114, 175, 29, 49, 11, 11, 126, 55, 189, 170, 46, 218, 240, 189, 144]
+  var sig: Signature
+  let success = sig.fromBytes(sigbytes)
+  doAssert not success
+
+test_invalid_infinity()
+
 # This test ensures that serialization roundtrips work
 
 echo "\nserialization roundtrip"


### PR DESCRIPTION
1. Harden against seemingly valid BLS signature. https://github.com/status-im/nimbus-eth2/issues/555 For a while the Milagro/Miracl backend accepted an infinity point as long as it has the infinity bit flag set, it didn't require the rest of the bits to be all zeros. The BLST backend wasn't affected. This was fixed in #121 (along with #64 and #74). The corresponding EF test is `deserialization_fails_infinity_with_true_b_flag.json` This PR merely adds https://github.com/status-im/nimbus-eth2/issues/555 as a dedicated test case