### PR TITLE
add `{.push: raises: [].}` annotation

### DIFF
--- a/blscurve.nimble
+++ b/blscurve.nimble
@@ -13,7 +13,7 @@ installFiles = @["blscurve.nim"]
 requires "nim >= 1.6.0",
          "nimcrypto",
          "stew",
-         "taskpools"
+         "taskpools >= 0.0.5"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use
 let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)

--- a/blscurve/bls_batch_verifier.nim
+++ b/blscurve/bls_batch_verifier.nim
@@ -14,6 +14,8 @@ import
 when compileOption("threads"):
   import taskpools, ./parallel_chunks
 
+{.push raises: [].}
+
 # BLS Batch Verifier
 # ----------------------------------------------------------------------
 # Nim supports for view types and openArray in object fields is experimental


### PR DESCRIPTION
In Nim 2.0, `bls_batch_verifier` seems to need `{.push: raises: [].}`.

```
/home/runner/work/nimbus-eth2/nimbus-eth2/nimcache/release/resttest/@m..@svendor@snim-bearssl@sbearssl@scsources@ssrc@scodec@senc16be.c.o /home/runner/work/nimbus-eth2/nimbus-eth2/vendor/nim-bearssl/bearssl/abi/../csources/src/codec/enc16be.c
/home/runner/work/nimbus-eth2/nimbus-eth2/vendor/nim-blscurve/blscurve/bls_batch_verifier.nim(246, 22) template/generic instantiation of `spawn` from here
/home/runner/work/nimbus-eth2/nimbus-eth2/vendor/nim-taskpools/taskpools/taskpools.nim(503, 70) template/generic instantiation of `toTask` from here
/home/runner/work/nimbus-eth2/nimbus-eth2/vendor/nim-taskpools/taskpools/tasks.nim(216, 65) template/generic instantiation from here
/home/runner/work/nimbus-eth2/nimbus-eth2/vendor/nim-taskpools/taskpools/tasks.nim(119, 20) Error: taskpool_reducePartialPairings(tp_4664066530, contexts_4664066532, start_4664066534,
                               stopEx_4664066536, fut_4664066538) can raise an unlisted exception: Exception
```