### PR TITLE
update instructions for tracking upstream MIRACL Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ binaries destined for older CPUs, pass `-d:BLSTuseSSSE3=0` to the Nim compiler.
 
 ### Keeping track of upstream
 
-To keep track of upstream AMCL:
+To keep track of upstream MIRACL Core:
 
 - Update the submodule.
-- Execute `nim e milagro.nims amcl blscurve/csources`
+- Execute `nim e milagro.nims vendor/miracl-core/c blscurve/miracl/csources`
 - Test
 - Commit
 

--- a/milagro.nims
+++ b/milagro.nims
@@ -1,13 +1,13 @@
 #!/usr/bin/env -S nim e
 mode = ScriptMode.Verbose
 
-## ## This script is Nim's replacement for config[32/64].py files of Milagro
+## This script is Nim's replacement for config[32/64].py files of Milagro
 ## library. It performs configuration of BLS381 curve for both 32bit and
 ## 64bit limbs. It also removes random/hash/crypto related functions.
 ##
 ## Usage:
 ##
-## nim -e milagro.nims <srcpath> <dstpath>
+## nim e milagro.nims <srcpath> <dstpath>
 ##
 ## <srcpath> - source path of milagro's C sources. By default current working
 ## path will be used.


### PR DESCRIPTION
Folders in README.md are no longer accurate. Bump to current structure.