### PR TITLE
rename `milagro.nims` -> `miracl.nims`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ binaries destined for older CPUs, pass `-d:BLSTuseSSSE3=0` to the Nim compiler.
 To keep track of upstream MIRACL Core:
 
 - Update the submodule.
-- Execute `nim e milagro.nims vendor/miracl-core/c blscurve/miracl/csources`
+- Execute `nim e miracl.nims vendor/miracl-core/c blscurve/miracl/csources`
 - Test
 - Commit
 

--- a/miracl.nims
+++ b/miracl.nims
@@ -1,15 +1,15 @@
 #!/usr/bin/env -S nim e
 mode = ScriptMode.Verbose
 
-## This script is Nim's replacement for config[32/64].py files of Milagro
+## This script is Nim's replacement for config[32/64].py files of Miracl
 ## library. It performs configuration of BLS381 curve for both 32bit and
 ## 64bit limbs. It also removes random/hash/crypto related functions.
 ##
 ## Usage:
 ##
-## nim e milagro.nims <srcpath> <dstpath>
+## nim e miracl.nims <srcpath> <dstpath>
 ##
-## <srcpath> - source path of milagro's C sources. By default current working
+## <srcpath> - source path of miracl's C sources. By default current working
 ## path will be used.
 ## <dstpath> - destination path where two directories `32` and `64` will be
 ## created and populated with generated BLS381 sources. By default current
@@ -622,4 +622,4 @@ curveSet(srcPath, dstPath64, "381", "BLS12381", "BLS12381", "58", "1", "-3",
          "-1", "NOT_SPECIAL", "0", "WEIERSTRASS", "0", "BLS12_CURVE",
          "M_TYPE", "NEGATIVEX", "69", "65", "128")
 
-echo "SUCCESS: Milagro source files was successfully prepared!"
+echo "SUCCESS: Miracl source files was successfully prepared!"


### PR DESCRIPTION
Followup from #66 where we switched from Milagro to MIRACL Core. The script to prepare C sources was not yet renamed. Doing now.