### PR TITLE
rename `milagro` references -> `miracl` in documentation

### DIFF
--- a/benchmarks/bls12381_curve.nim
+++ b/benchmarks/bls12381_curve.nim
@@ -196,7 +196,7 @@ else:
     let generator = generator1()
     let Q = hashToG2(msg, domainSepTag)
     # Pairing: e(Q, xP) == e(R, P)
-    bench("Pairing (Milagro builtin double pairing)", iters):
+    bench("Pairing (Miracl builtin double pairing)", iters):
       let valid = doublePairing(
         Q, pubkey,
         sig, generator

--- a/benchmarks/platforms/x86.nim
+++ b/benchmarks/platforms/x86.nim
@@ -1,7 +1,7 @@
 # Cpu Name
 # -------------------------------------------------------
 
-{.passc:"-std=gnu99".} # TODO may conflict with milagro "-std=c99"
+{.passc:"-std=gnu99".} # TODO may conflict with miracl "-std=c99"
 
 proc cpuID(eaxi, ecxi: int32): tuple[eax, ebx, ecx, edx: int32] =
   when defined(vcc):
@@ -74,4 +74,3 @@ proc getTicks*(): int64 {.inline.} =
         : "memory"
       );""".}
       return res
-

--- a/blscurve/bls_batch_verifier.nim
+++ b/blscurve/bls_batch_verifier.nim
@@ -29,7 +29,7 @@ when compileOption("threads"):
 # hence 176B only
 #
 # TODO: Once ContextMultiAggregateVerify is implemented
-# for Milagro/Miracl, this wouldn't need to be in the BLST specific file
+# for Miracl, this wouldn't need to be in the BLST specific file
 
 type
   SignatureSet* = tuple[pubkey: PublicKey, message: array[32, byte], signature: Signature]

--- a/blscurve/eth2_keygen/eth2_keygen.nim
+++ b/blscurve/eth2_keygen/eth2_keygen.nim
@@ -90,7 +90,7 @@ when BLS_BACKEND == Miracl:
 
     # 3. not_IKM = flip_bits(parent_SK)
     # We can flip the bit of the IKM instead
-    # as flipping bits of milagro representation (Montgomery)
+    # as flipping bits of miracl representation (Montgomery)
     # doesn't make sense
     var not_ikm {.noinit.}: array[32, byte]
     for i in 0 ..< 32:

--- a/blscurve/miracl/common.nim
+++ b/blscurve/miracl/common.nim
@@ -510,7 +510,7 @@ proc toBytes*(a: BIG_384, res: var openArray[byte]): bool =
   if len(res) == MODBYTES_384:
     var c: BIG_384
     BIG_384_copy(c, a)
-    # BIG_384_norm() function in Milagro operates inplace.
+    # BIG_384_norm() function in Miracl operates inplace.
     discard BIG_384_norm(c)
     for i in countdown(MODBYTES_384 - 1, 0):
       res[i] = byte(c[0] and 0xFF)
@@ -542,7 +542,7 @@ func fromBytes*(res: var DBIG_384, a: openArray[byte]): bool =
   ## Unserialize double big integer from ``a`` to ``res``.
   ## Length of ``a`` must be at least ``2*MODBYTES_384_29``.
 
-  # TODO: there is no length check in Milagro BIG_384_29_dfromBytesLen
+  # TODO: there is no length check in Miracl BIG_384_29_dfromBytesLen
   #       is that normal?
   zeroMem(res.addr, sizeof(res))
   for rawByte in a:

--- a/blscurve/miracl/hash_to_curve.nim
+++ b/blscurve/miracl/hash_to_curve.nim
@@ -453,16 +453,16 @@ func clearCofactor*(P: var ECP2_BLS12381) =
   # - Psi (ψ) - untwist-Frobenius-Twist function
   # - Addition-chain: https://en.wikipedia.org/wiki/Addition_chain / https://en.wikipedia.org/wiki/Addition-chain_exponentiation
   #
-  # Budroni's paper mention an implementation in Milagro of BLS G2 hashmaps.
+  # Budroni's paper mention an implementation in Miracl of BLS G2 hashmaps.
   # We reuse the relevant clearCofactor routines from ``ECP2_BLS12381_mapit``
-  # In Milagro terms: "Q -> x2Q -xQ -Q +F(xQ -Q) +F(F(2Q))"
+  # In Miracl terms: "Q -> x2Q -xQ -Q +F(xQ -Q) +F(F(2Q))"
   #
   # We use the notation from Riad Wahby
   # "P -> (x^2 - x - 1) P + (x - 1) psi(P) + psi(psi(2P))"
   #
   # with:
-  # - P     (Wahby), Q   (Milagro) being the input point
-  # - psi() (Wahby), F() (Milagro) being the untwist-Frobenius-twist mapping
+  # - P     (Wahby), Q   (Miracl) being the input point
+  # - psi() (Wahby), F() (Miracl) being the untwist-Frobenius-twist mapping
   #
   # Note: CurveNegX = -x
   {.noSideEffect.}:

--- a/blscurve/miracl/miracl.nim
+++ b/blscurve/miracl/miracl.nim
@@ -7,7 +7,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-# Milagro should be compiled for C99.
+# Miracl should be compiled for C99.
 # This statement checks to see if we're using a backend other then C,
 # and if not, passes C99.
 # We would just check for C except Nim only defines the other backends.


### PR DESCRIPTION
Followup from #66 where we switched from Milagro to MIRACL Core. The internal documentation was not fully updated for Miracl. Doing now.