### PR TITLE
Regenerate `blst_abi.nim`

### DIFF
--- a/blscurve/blst/blst_min_pubkey_sig_core.nim
+++ b/blscurve/blst/blst_min_pubkey_sig_core.nim
@@ -203,7 +203,7 @@ template genAggregatorProcedures(
     agg.aggregate(elems.toOpenArray(1, elems.high))
     `blst _ p1_or_p2 _ cneg`(
       toCV(agg.point, `cblst _ p1_or_p2`),
-      cbit = 1
+      cbit = true
     )
     agg.aggregate(dst)
     dst.finish(agg)

--- a/tests/t_batch_verifier.nim
+++ b/tests/t_batch_verifier.nim
@@ -178,7 +178,10 @@ proc genForgedPair(batch: var seq[SignatureSet],
   # 1. Create -S'. Note: if P has elliptic affine coordinates (x, y) then -P is (x, -y)
   var neg_sigp = sigp
   let neg_sigp_ptr = cast[ptr blst_p2_affine](neg_sigp.addr)
-  blst_fp2_cneg(toCV(neg_sigp_ptr[].y, cblst_fp2), toCC(neg_sigp_ptr[].y, cblst_fp2), 1)
+  blst_fp2_cneg(
+    toCV(neg_sigp_ptr[].y, cblst_fp2),
+    toCC(neg_sigp_ptr[].y, cblst_fp2),
+    flag = true)
 
   # 2. Forge signatures S1+S' and S2-S'
   var forgedSig1s, forgedSig2ns: Signature


### PR DESCRIPTION
Use latest `csources` to regenerate `blst_abi.nim` and re-apply manual customization steps to minimize diff.