### PR TITLE
Expose Pippenger multiplication for combining multiple sigs of same msg

### DIFF
--- a/benchmarks/bench_all.nim
+++ b/benchmarks/bench_all.nim
@@ -1,3 +1,12 @@
+# Nim-BLSCurve
+# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
 import
   std/[os, strutils, cpuinfo],
   ../blscurve,
@@ -29,28 +38,31 @@ benchFastAggregateVerify(numKeys = 128, iters = 10)
 separator()
 
 when BLS_BACKEND == BLST:
-    var nthreads: int
-    if existsEnv"TP_NUM_THREADS":
-      nthreads = getEnv"TP_NUM_THREADS".parseInt()
-    else:
-      nthreads = countProcessors()
+  var nthreads: int
+  if existsEnv"TP_NUM_THREADS":
+    nthreads = getEnv"TP_NUM_THREADS".parseInt()
+  else:
+    nthreads = countProcessors()
 
-    # Simulate Block verification (at most 6 signatures per block)
-    batchVerifyMulti(numSigs = 6, iters = 10)
-    batchVerifyMultiBatchedSerial(numSigs = 6, iters = 10)
-    batchVerifyMultiBatchedParallel(numSigs = 6, iters = 10, nthreads)
-    separator()
+  # Simulate Block verification (at most 6 signatures per block)
+  batchVerifyMulti(numSigs = 6, iters = 10)
+  batchVerifyMultiSameMessage(numSigs = 6, iters = 10)
+  batchVerifyMultiBatchedSerial(numSigs = 6, iters = 10)
+  batchVerifyMultiBatchedParallel(numSigs = 6, iters = 10, nthreads)
+  separator()
 
-    # Simulate 10 blocks verification
-    batchVerifyMulti(numSigs = 60, iters = 10)
-    batchVerifyMultiBatchedSerial(numSigs = 60, iters = 10)
-    batchVerifyMultiBatchedParallel(numSigs = 60, iters = 10, nthreads)
-    separator()
+  # Simulate 10 blocks verification
+  batchVerifyMulti(numSigs = 60, iters = 10)
+  batchVerifyMultiSameMessage(numSigs = 60, iters = 10)
+  batchVerifyMultiBatchedSerial(numSigs = 60, iters = 10)
+  batchVerifyMultiBatchedParallel(numSigs = 60, iters = 10, nthreads)
+  separator()
 
-    # Simulate 30 blocks verification
-    batchVerifyMulti(numSigs = 180, iters = 10)
-    batchVerifyMultiBatchedSerial(numSigs = 180, iters = 10)
-    batchVerifyMultiBatchedParallel(numSigs = 180, iters = 10, nthreads)
-    separator()
+  # Simulate 30 blocks verification
+  batchVerifyMulti(numSigs = 180, iters = 10)
+  batchVerifyMultiSameMessage(numSigs = 180, iters = 10)
+  batchVerifyMultiBatchedSerial(numSigs = 180, iters = 10)
+  batchVerifyMultiBatchedParallel(numSigs = 180, iters = 10, nthreads)
+  separator()
 
-    echo "\nUsing nthreads = ", nthreads, ". The number of threads can be changed with TP_NUM_THREADS environment variable."
+  echo "\nUsing nthreads = ", nthreads, ". The number of threads can be changed with TP_NUM_THREADS environment variable."

--- a/blscurve/blst/blst+nim.h
+++ b/blscurve/blst/blst+nim.h
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2024 Status Research & Development GmbH
+ * Licensed under either of
+ *  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+ *  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+ * at your option.
+ * This file may not be copied, modified, or distributed except according to
+ * those terms.
+ */
+
+#ifndef BLST_NIM_H
+#define BLST_NIM_H
+
+// Nim does not support annotating pointer destinations with C `const`.
+//
+// This leads to errors on certain platforms and toolchains, e.g.:
+//     expected 'const blst_p1_affine * const*'
+//     but argument is of type 'blst_p1_affine **'
+//     [-Wincompatible-pointer-types]
+//
+// To prevent these issues, offending function signatures are replaced
+// with ones that lack C `const` annotations.
+
+
+#define blst_p1s_to_affine blst_p1s_to_affine_replaced
+#define blst_p1s_add blst_p1s_add_replaced
+#define blst_p1s_mult_wbits_precompute blst_p1s_mult_wbits_precompute_replaced
+#define blst_p1s_mult_wbits blst_p1s_mult_wbits_replaced
+#define blst_p1s_mult_pippenger blst_p1s_mult_pippenger_replaced
+#define blst_p1s_tile_pippenger blst_p1s_tile_pippenger_replaced
+
+#define blst_p2s_to_affine blst_p2s_to_affine_replaced
+#define blst_p2s_add blst_p2s_add_replaced
+#define blst_p2s_mult_wbits_precompute blst_p2s_mult_wbits_precompute_replaced
+#define blst_p2s_mult_wbits blst_p2s_mult_wbits_replaced
+#define blst_p2s_mult_pippenger blst_p2s_mult_pippenger_replaced
+#define blst_p2s_tile_pippenger blst_p2s_tile_pippenger_replaced
+
+#define blst_miller_loop_n blst_miller_loop_n_replaced
+
+#include "../../vendor/blst/bindings/blst.h"
+
+#undef blst_p1s_to_affine
+#undef blst_p1s_add
+#undef blst_p1s_mult_wbits_precompute
+#undef blst_p1s_mult_wbits
+#undef blst_p1s_mult_pippenger
+#undef blst_p1s_tile_pippenger
+
+#undef blst_p2s_to_affine
+#undef blst_p2s_add
+#undef blst_p2s_mult_wbits_precompute
+#undef blst_p2s_mult_wbits
+#undef blst_p2s_mult_pippenger
+#undef blst_p2s_tile_pippenger
+
+#undef blst_miller_loop_n
+
+void blst_p1s_to_affine(blst_p1_affine dst[], blst_p1 *points[],
+                        size_t npoints);
+void blst_p1s_add(blst_p1 *ret, blst_p1_affine *points[],
+                                size_t npoints);
+void blst_p1s_mult_wbits_precompute(blst_p1_affine table[], size_t wbits,
+                                    blst_p1_affine *points[],
+                                    size_t npoints);
+void blst_p1s_mult_wbits(blst_p1 *ret, const blst_p1_affine table[],
+                         size_t wbits, size_t npoints,
+                         byte *scalars[], size_t nbits,
+                         limb_t *scratch);
+void blst_p1s_mult_pippenger(blst_p1 *ret, blst_p1_affine *points[],
+                             size_t npoints, byte *scalars[],
+                             size_t nbits, limb_t *scratch);
+void blst_p1s_tile_pippenger(blst_p1 *ret, blst_p1_affine *points[],
+                             size_t npoints, byte *scalars[],
+                             size_t nbits, limb_t *scratch,
+                             size_t bit0, size_t window);
+
+void blst_p2s_to_affine(blst_p2_affine dst[], blst_p2 *points[],
+                        size_t npoints);
+void blst_p2s_add(blst_p2 *ret, blst_p2_affine *points[],
+                                size_t npoints);
+void blst_p2s_mult_wbits_precompute(blst_p2_affine table[], size_t wbits,
+                                    blst_p2_affine *points[],
+                                    size_t npoints);
+void blst_p2s_mult_wbits(blst_p2 *ret, const blst_p2_affine table[],
+                         size_t wbits, size_t npoints,
+                         byte *scalars[], size_t nbits,
+                         limb_t *scratch);
+void blst_p2s_mult_pippenger(blst_p2 *ret, blst_p2_affine *points[],
+                             size_t npoints, byte *scalars[],
+                             size_t nbits, limb_t *scratch);
+void blst_p2s_tile_pippenger(blst_p2 *ret, blst_p2_affine *points[],
+                             size_t npoints, byte *scalars[],
+                             size_t nbits, limb_t *scratch,
+                             size_t bit0, size_t window);
+
+void blst_miller_loop_n(blst_fp12 *ret, blst_p2_affine *Qs[],
+                                        blst_p1_affine *Ps[],
+                                        size_t n);
+
+#endif

--- a/blscurve/blst/blst+nim.h
+++ b/blscurve/blst/blst+nim.h
@@ -13,14 +13,14 @@
 
 // Nim does not support annotating pointer destinations with C `const`.
 //
-// This leads to errors on certain platforms and toolchains, e.g.:
+// This leads to errors on certain platforms and toolchains
+// when interacting with APIs involving nested pointers, e.g.:
 //     expected 'const blst_p1_affine * const*'
 //     but argument is of type 'blst_p1_affine **'
 //     [-Wincompatible-pointer-types]
 //
 // To prevent these issues, offending function signatures are replaced
 // with ones that lack C `const` annotations.
-
 
 #define blst_p1s_to_affine blst_p1s_to_affine_replaced
 #define blst_p1s_add blst_p1s_add_replaced

--- a/blscurve/blst/blst_abi.nim
+++ b/blscurve/blst/blst_abi.nim
@@ -2,7 +2,7 @@
 # Manual edits
 import std/[strutils, os]
 
-const headerPath = currentSourcePath.rsplit({DirSep, AltSep}, 1)[0] & "/../../vendor/blst/bindings/blst.h"
+const headerPath = currentSourcePath.rsplit({DirSep, AltSep}, 1)[0] & "/blst+nim.h"
 
 {.pragma: blst, importc, header: headerPath.}
 {.pragma: blstheader, header: headerPath.}

--- a/blscurve/blst/blst_abi.nim
+++ b/blscurve/blst/blst_abi.nim
@@ -320,43 +320,49 @@ proc blst_p2_affine_is_inf*(a: ptr cblst_p2_affine): CTbool
 proc blst_p2_affine_generator*(): ptr cblst_p2_affine
 
 # Multi-scalar multiplications and other multi-point operations.
-proc blst_p1s_to_affine*(dst: UncheckedArray[cblst_p1_affine]; points: cblst_p1;
+proc blst_p1s_to_affine*(dst: ptr cblst_p1_affine; points: ptr ptr cblst_p1;
                          npoints: uint)
-proc blst_p1s_add*(ret: ptr cblst_p1; points: cblst_p1_affine; npoints: uint)
+proc blst_p1s_add*(ret: ptr cblst_p1;
+                   points: ptr ptr cblst_p1_affine; npoints: uint)
 proc blst_p1s_mult_wbits_precompute_sizeof*(wbits: uint; npoints: uint): uint
-proc blst_p1s_mult_wbits_precompute*(table: UncheckedArray[cblst_p1_affine];
-                                     wbits: uint; points: cblst_p1_affine;
+proc blst_p1s_mult_wbits_precompute*(table: ptr cblst_p1_affine; wbits: uint;
+                                     points: ptr ptr cblst_p1_affine;
                                      npoints: uint)
 proc blst_p1s_mult_wbits_scratch_sizeof*(npoints: uint): uint
-proc blst_p1s_mult_wbits*(ret: ptr cblst_p1;
-                          table: UncheckedArray[cblst_p1_affine]; wbits: uint;
-                          npoints: uint; scalars: byte; nbits: uint;
+proc blst_p1s_mult_wbits*(ret: ptr cblst_p1; table: ptr cblst_p1_affine;
+                          wbits: uint; npoints: uint;
+                          scalars: ptr ptr byte; nbits: uint;
                           scratch: ptr limb_t)
 proc blst_p1s_mult_pippenger_scratch_sizeof*(npoints: uint): uint
-proc blst_p1s_mult_pippenger*(ret: ptr cblst_p1; points: cblst_p1_affine;
-                              npoints: uint; scalars: byte; nbits: uint;
+proc blst_p1s_mult_pippenger*(ret: ptr cblst_p1;
+                              points: ptr ptr cblst_p1_affine; npoints: uint;
+                              scalars: ptr ptr byte; nbits: uint;
                               scratch: ptr limb_t)
-proc blst_p1s_tile_pippenger*(ret: ptr cblst_p1; points: cblst_p1_affine;
-                              npoints: uint; scalars: byte; nbits: uint;
+proc blst_p1s_tile_pippenger*(ret: ptr cblst_p1;
+                              points: ptr ptr cblst_p1_affine; npoints: uint;
+                              scalars: ptr ptr byte; nbits: uint;
                               scratch: ptr limb_t; bit0: uint; window: uint)
-proc blst_p2s_to_affine*(dst: UncheckedArray[cblst_p2_affine]; points: cblst_p2;
+proc blst_p2s_to_affine*(dst: ptr cblst_p2_affine; points: ptr ptr cblst_p2;
                          npoints: uint)
-proc blst_p2s_add*(ret: ptr cblst_p2; points: cblst_p2_affine; npoints: uint)
+proc blst_p2s_add*(ret: ptr cblst_p2;
+                   points: ptr ptr cblst_p2_affine; npoints: uint)
 proc blst_p2s_mult_wbits_precompute_sizeof*(wbits: uint; npoints: uint): uint
-proc blst_p2s_mult_wbits_precompute*(table: UncheckedArray[cblst_p2_affine];
-                                     wbits: uint; points: cblst_p2_affine;
+proc blst_p2s_mult_wbits_precompute*(table: ptr cblst_p2_affine; wbits: uint;
+                                     points: ptr ptr cblst_p2_affine;
                                      npoints: uint)
 proc blst_p2s_mult_wbits_scratch_sizeof*(npoints: uint): uint
-proc blst_p2s_mult_wbits*(ret: ptr cblst_p2;
-                          table: UncheckedArray[cblst_p2_affine]; wbits: uint;
-                          npoints: uint; scalars: byte; nbits: uint;
+proc blst_p2s_mult_wbits*(ret: ptr cblst_p2; table: ptr cblst_p2_affine;
+                          wbits: uint; npoints: uint;
+                          scalars: ptr ptr byte; nbits: uint;
                           scratch: ptr limb_t)
 proc blst_p2s_mult_pippenger_scratch_sizeof*(npoints: uint): uint
-proc blst_p2s_mult_pippenger*(ret: ptr cblst_p2; points: cblst_p2_affine;
-                              npoints: uint; scalars: byte; nbits: uint;
+proc blst_p2s_mult_pippenger*(ret: ptr cblst_p2;
+                              points: ptr ptr cblst_p2_affine; npoints: uint;
+                              scalars: ptr ptr byte; nbits: uint;
                               scratch: ptr limb_t)
-proc blst_p2s_tile_pippenger*(ret: ptr cblst_p2; points: cblst_p2_affine;
-                              npoints: uint; scalars: byte; nbits: uint;
+proc blst_p2s_tile_pippenger*(ret: ptr cblst_p2;
+                              points: ptr ptr cblst_p2_affine; npoints: uint;
+                              scalars: ptr ptr byte; nbits: uint;
                               scratch: ptr limb_t; bit0: uint; window: uint)
 
 # Hash-to-curve operations.
@@ -446,8 +452,8 @@ proc blst_sign_pk_in_g2*(out_sig: ptr cblst_p1; hash: ptr cblst_p1;
 
 proc blst_miller_loop*(ret: ptr cblst_fp12; Q: ptr cblst_p2_affine;
                        P: ptr cblst_p1_affine)
-proc blst_miller_loop_n*(ret: ptr cblst_fp12; Qs: cblst_p2_affine;
-                         Ps: cblst_p1_affine; n: uint)
+proc blst_miller_loop_n*(ret: ptr cblst_fp12; Qs: ptr ptr cblst_p2_affine;
+                         Ps: ptr ptr cblst_p1_affine; n: uint)
 proc blst_final_exp*(ret: ptr cblst_fp12; f: ptr cblst_fp12)
 proc blst_precompute_lines*(Qlines: var array[68, cblst_fp6]; Q: ptr cblst_p2_affine)
 proc blst_miller_loop_lines*(ret: ptr cblst_fp12; Qlines: array[68, cblst_fp6];

--- a/blscurve/blst/blst_min_pubkey_sig_core.nim
+++ b/blscurve/blst/blst_min_pubkey_sig_core.nim
@@ -567,21 +567,6 @@ func update*[T: char|byte](
     aug = ""
   )
 
-template ignoringIncompatiblePointerTypes(body: untyped): untyped =
-  # Nim does not support annotating pointer destinations with C `const`
-  {.emit: """
-    #ifdef __clang__
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-    #endif
-    """.}
-  body
-  {.emit: """
-    #ifdef __clang__
-    #pragma GCC diagnostic pop
-    #endif
-    """.}
-
 func combine*(
          secureRandomBytes: array[32, byte],
          publicKeys: openArray[PublicKey],
@@ -635,29 +620,23 @@ func combine*(
       signature {.noinit.}: Signature
     block:
       var combinedPublicKey {.noinit.}: AggregatePublicKey
-      ignoringIncompatiblePointerTypes:
-        # expected 'const blst_p1_affine * const*'
-        # but argument is of type 'blst_p1_affine **'
-        blst_p1s_mult_pippenger(
-          toCV(combinedPublicKey, cblst_p1),
-          publicKeysRef[0].unsafeAddr,
-          numEntries,
-          scalarsRef[0].unsafeAddr,
-          nbits = 64,
-          scratch[0].addr)
+      blst_p1s_mult_pippenger(
+        toCV(combinedPublicKey, cblst_p1),
+        publicKeysRef[0].unsafeAddr,
+        numEntries,
+        scalarsRef[0].unsafeAddr,
+        nbits = 64,
+        scratch[0].addr)
       publicKey.finish combinedPublicKey
     block:
       var combinedSignature {.noinit.}: AggregateSignature
-      ignoringIncompatiblePointerTypes:
-        # expected 'const blst_p2_affine * const*'
-        # but argument is of type 'blst_p2_affine **'
-        blst_p2s_mult_pippenger(
-          toCV(combinedSignature, cblst_p2),
-          signaturesRef[0].unsafeAddr,
-          numEntries,
-          scalarsRef[0].unsafeAddr,
-          nbits = 64,
-          scratch[0].addr)
+      blst_p2s_mult_pippenger(
+        toCV(combinedSignature, cblst_p2),
+        signaturesRef[0].unsafeAddr,
+        numEntries,
+        scalarsRef[0].unsafeAddr,
+        nbits = 64,
+        scratch[0].addr)
       signature.finish combinedSignature
     (publicKey, signature)
 


### PR DESCRIPTION
In many use cases, there are multiple signatures of the same message, e.g., Ethereum attestations often share the signed `AttestationData`.

For that situation, `blst` started exposing Pippenger multiplication to accelerate this use case. Multiscalar multiplication is much faster than individual scalar multiplication of each signature / pubkey.

Further optimizations may be achieved with parallel tiling, see the Rust binding code in the `npoints >= 32` situation:

- https://github.com/supranational/blst/blob/v0.3.13/bindings/rust/src/pippenger.rs

Likewise, multiple pubkeys / signatures may be loaded simultaneously using the new `blst` APIs.

We don't do either of these additional optimizations as our architecture does not readily support them. Pippenger multiplication alone already offers a significant speedup until prioritizing further optimizations.

```
------------------------------------------------------------------------------------------------------------------------------------
BLS verif of 6 msgs by 6 pubkeys                                                117.232 ops/s      8530098 ns/op     20471994 cycles
BLS verif of 6 sigs of same msg by 6 pubkeys (with blinding)                    553.186 ops/s      1807711 ns/op      4338371 cycles
BLS verif of 6 sigs of same msg by 6 pubkeys                                    724.279 ops/s      1380683 ns/op      3313617 cycles
------------------------------------------------------------------------------------------------------------------------------------
BLS verif of 60 msgs by 60 pubkeys                                               11.131 ops/s     89839743 ns/op    215615251 cycles
BLS verif of 60 sigs of same msg by 60 pubkeys (with blinding)                  238.059 ops/s      4200634 ns/op     10081380 cycles
BLS verif of 60 sigs of same msg by 60 pubkeys                                  680.634 ops/s      1469219 ns/op      3526031 cycles
------------------------------------------------------------------------------------------------------------------------------------
BLS verif of 180 msgs by 180 pubkeys                                              3.887 ops/s    257298895 ns/op    617517127 cycles
BLS verif of 180 sigs of same msg by 180 pubkeys (with blinding)                166.340 ops/s      6011785 ns/op     14428186 cycles
BLS verif of 180 sigs of same msg by 180 pubkeys                                536.938 ops/s      1862413 ns/op      4469689 cycles
------------------------------------------------------------------------------------------------------------------------------------
```